### PR TITLE
67-mm-testTriangles

### DIFF
--- a/braph/graph/measures/Triangles.m
+++ b/braph/graph/measures/Triangles.m
@@ -18,19 +18,14 @@ classdef Triangles < Measure
                 
                 switch lower(directed_triangles_rule)
                     case {'all'}  % all rule
-                        A = double(A);
                         triangles = diag((A.^(1/3) + transpose(A).^(1/3))^3)/2;
                     case {'middleman'}  % middleman rule
-                        A = double(A);
                         triangles = diag(A.^(1/3) * transpose(A).^(1/3) * A.^(1/3));
                     case {'in'}  % in rule
-                        A = double(A);
                         triangles = diag(transpose(A).^(1/3) * (A.^(1/3))^2);
                     case {'out'}  % in rule
-                        A = double(A);
                         triangles = diag((A.^(1/3))^2 * transpose(A).^(1/3));
                     otherwise  % {'cycle'}  % cycle rule
-                        A = double(A);
                         triangles = diag((A.^(1/3))^3);
                 end
             end

--- a/braph/graph/measures/Triangles.m
+++ b/braph/graph/measures/Triangles.m
@@ -19,19 +19,19 @@ classdef Triangles < Measure
                 switch lower(directed_triangles_rule)
                     case {'all'}  % all rule
                         A = double(A);
-                        triangles = diag((A + transpose(A))^3)/2;
+                        triangles = diag((A.^(1/3) + transpose(A).^(1/3))^3)/2;
                     case {'middleman'}  % middleman rule
                         A = double(A);
-                        triangles = diag(A * transpose(A) * A);
+                        triangles = diag(A.^(1/3) * transpose(A).^(1/3) * A.^(1/3));
                     case {'in'}  % in rule
                         A = double(A);
-                        triangles = diag(transpose(A)*A^2);
+                        triangles = diag(transpose(A).^(1/3) * (A.^(1/3))^2);
                     case {'out'}  % in rule
                         A = double(A);
-                        triangles = diag(A^2*transpose(A));
+                        triangles = diag((A.^(1/3))^2 * transpose(A).^(1/3));
                     otherwise  % {'cycle'}  % cycle rule
                         A = double(A);
-                        triangles = diag(A^3);
+                        triangles = diag((A.^(1/3))^3);
                 end
             end
         end

--- a/braph/graph/measures/test_Triangles.m
+++ b/braph/graph/measures/test_Triangles.m
@@ -1,16 +1,16 @@
 % test Triangles
 A_BD = [
-    0 0 1 1; 
-    1 0 0 1; 
-    0 1 0 1; 
+    0 0 1 1;
+    1 0 0 1;
+    0 1 0 1;
     0 0 0 0
     ];
 triangles_BD = [0 0 0 3]'; % in rule
 
 A_BU = [
-    0 1 1 1; 
-    1 0 1 0; 
-    1 1 0 1; 
+    0 1 1 1;
+    1 0 1 0;
+    1 1 0 1;
     1 0 1 0
     ];
 triangles_BU = [2 1 2 1]';
@@ -79,6 +79,7 @@ S=A+A.';                    %symmetrized input graph
 cyc3=diag(S^3)/2;           %number of 3-cycles (ie. directed triangles)
 stdvalue_BD=cyc3;           %clustering coefficient
 end
+
 function stdvalue_BU = triangles_standard_BU(A)
 n = length(A);
 stdvalue_BU = zeros(n,1);
@@ -91,11 +92,13 @@ for u = 1:n
     end
 end
 end
+
 function stdvalue_WD = triangles_standard_WD(A)
 S=A.^(1/3)+(A.').^(1/3);	%symmetrized weights matrix ^1/3
 cyc3=diag(S^3)/2;           %number of 3-cycles (ie. directed triangles)
 stdvalue_WD=cyc3;               %clustering coefficient
 end
+
 function stdvalue_WU = triangles_standard_WU(A)
 cyc3=diag((A.^(1/3))^3);
 stdvalue_WU=cyc3/2;

--- a/braph/graph/measures/test_Triangles.m
+++ b/braph/graph/measures/test_Triangles.m
@@ -73,7 +73,7 @@ assert(isequal(valueWU_braph2, valueWU_std), ...
     'BRAPH:Triangles:Bug', ...
     'Triangles is not beeing calculated correctly for GraphWU')
 
-% Functions to calcualte triangled from 2019_03_03_BCT
+% Functions to calcualte triangles from 2019_03_03_BCT
 function stdvalue_BD = triangles_standard_BD(A)
 S=A+A.';                    %symmetrized input graph
 cyc3=diag(S^3)/2;           %number of 3-cycles (ie. directed triangles)

--- a/braph/graph/measures/test_Triangles.m
+++ b/braph/graph/measures/test_Triangles.m
@@ -1,0 +1,91 @@
+% test Triangles
+A_BD = [0 0 1 1; 1 0 0 1; 0 1 0 1; 0 0 0 0];
+triangles_BD = [0; 0; 0; 3]; % in rule
+A_BU = [0 1 1 1; 1 0 1 0; 1 1 0 1; 1 0 1 0];
+triangles_BU = [2; 1; 2; 1];
+
+A_test = randn(randi(10));
+
+%% Test 1: Comparison with known BD graph
+gBD = GraphBD(A_BD);
+mBD = Triangles(gBD,'DirectedTrianglesRule', 'in');
+valueBD = mBD.getValue();
+assert(isequal(valueBD, triangles_BD), ...
+    'BRAPH:Triangles:Bug', ...
+    'Triangles is not beeing calculated correctly for GraphBD')
+
+%% Test 2: Comparison with known BU graphs
+gBU = GraphBU(A_BU);
+mBU = Triangles(gBU);
+valueBU = mBU.getValue();
+assert(isequal(valueBU, triangles_BU), ...
+    'BRAPH:Triangles:Bug', ...
+    'Triangles is not beeing calculated correctly for GraphBU')
+
+%% Test 3: Comparison with standard method for BD graphs
+gBD_braph2 = GraphBD(A_test); A_BD = gBD_braph2.getA();
+mBD_braph2 = Triangles(gBD_braph2, 'DirectedTrianglesRule', 'all');
+% calculate the values by Braph2 and standard methods
+valueBD_braph2 = mBD_braph2.getValue();
+valueBD_std = triangles_standard_BD(A_BD);
+assert(isequal(valueBD_braph2, valueBD_std), ...
+    'BRAPH:Triangles:Bug', ...
+    'Triangles is not beeing calculated correctly for GraphBD')
+
+%% Test 4: Comparison with standard method for BU graphs
+gBU_braph2 = GraphBU(A_test); A_BU = gBU_braph2.getA();
+mBU_braph2 = Triangles(gBU_braph2);
+% calculate the values by Braph2 and standard methods
+valueBU_braph2 = mBU_braph2.getValue();
+valueBU_std = triangles_standard_BU(A_BU);
+assert(isequal(valueBU_braph2, valueBU_std), ...
+    'BRAPH:Triangles:Bug', ...
+    'Triangles is not beeing calculated correctly for GraphBU')
+
+%% Test 5: Comparison with standard method for WD graphs
+gWD_braph2 = GraphWD(A_test); A_WD = gWD_braph2.getA();
+mWD_braph2 = Triangles(gWD_braph2, 'DirectedTrianglesRule', 'all');
+% calculate the values by Braph2 and standard methods
+valueWD_braph2 = mWD_braph2.getValue();
+valueWD_std = triangles_standard_WD(A_WD);
+assert(isequal(valueWD_braph2, valueWD_std), ...
+    'BRAPH:Triangles:Bug', ...
+    'Triangles is not beeing calculated correctly for GraphWD')
+
+%% Test 6: Comparison with standard method for WU graphs
+gWU_braph2 = GraphWU(A_test); A_WU = gWU_braph2.getA();
+mWU_braph2 = Triangles(gWU_braph2);
+% calculate the values by Braph2 and standard methods
+valueWU_braph2 = mWU_braph2.getValue();
+valueWU_std = triangles_standard_WU(A_WU);
+assert(isequal(valueWU_braph2, valueWU_std), ...
+    'BRAPH:Triangles:Bug', ...
+    'Triangles is not beeing calculated correctly for GraphWU')
+
+% standard functions to calculate triangles
+function stdvalue_BD = triangles_standard_BD(A)
+S=A+A.';                    %symmetrized input graph
+cyc3=diag(S^3)/2;           %number of 3-cycles (ie. directed triangles)
+stdvalue_BD=cyc3;           %clustering coefficient
+end
+function stdvalue_BU = triangles_standard_BU(A)
+n = length(A);
+stdvalue_BU = zeros(n,1);
+for u = 1:n
+    V = find(A(u,:));
+    k = length(V);
+    if k>=2                 %degree must be at least 2
+        S = A(V,V);
+        stdvalue_BU(u) = sum(S(:))/ 2;
+    end
+end
+end
+function stdvalue_WD = triangles_standard_WD(A)
+S=A.^(1/3)+(A.').^(1/3);	%symmetrized weights matrix ^1/3
+cyc3=diag(S^3)/2;           %number of 3-cycles (ie. directed triangles)
+stdvalue_WD=cyc3;               %clustering coefficient
+end
+function stdvalue_WU = triangles_standard_WU(A)
+cyc3=diag((A.^(1/3))^3);
+stdvalue_WU=cyc3/2;
+end

--- a/braph/graph/measures/test_Triangles.m
+++ b/braph/graph/measures/test_Triangles.m
@@ -1,8 +1,19 @@
 % test Triangles
-A_BD = [0 0 1 1; 1 0 0 1; 0 1 0 1; 0 0 0 0];
-triangles_BD = [0; 0; 0; 3]; % in rule
-A_BU = [0 1 1 1; 1 0 1 0; 1 1 0 1; 1 0 1 0];
-triangles_BU = [2; 1; 2; 1];
+A_BD = [
+    0 0 1 1; 
+    1 0 0 1; 
+    0 1 0 1; 
+    0 0 0 0
+    ];
+triangles_BD = [0 0 0 3]'; % in rule
+
+A_BU = [
+    0 1 1 1; 
+    1 0 1 0; 
+    1 1 0 1; 
+    1 0 1 0
+    ];
+triangles_BU = [2 1 2 1]';
 
 A_test = randn(randi(10));
 
@@ -62,7 +73,7 @@ assert(isequal(valueWU_braph2, valueWU_std), ...
     'BRAPH:Triangles:Bug', ...
     'Triangles is not beeing calculated correctly for GraphWU')
 
-% standard functions to calculate triangles
+% Functions to calcualte triangled from 2019_03_03_BCT
 function stdvalue_BD = triangles_standard_BD(A)
 S=A+A.';                    %symmetrized input graph
 cyc3=diag(S^3)/2;           %number of 3-cycles (ie. directed triangles)


### PR DESCRIPTION
Test function for the Triangles measure created.

Also, the calculations for the triangles measured were changes in order to make them correct, mainly this was needed for weighted graphs. Basically, for weighted graphs each binary adjacency matrix (A) is substituted with W^1/3 where W is the weighted adjacency matrix. This is needed in order to normalize when three weights are multiplied together.

A suggestion: Since the double(A) has already been added to binarize function, maybe we can remove that line from the calculations in the triangles.