### PR TITLE
GUI BrainAtlas - adding brain regions manually

### DIFF
--- a/braph2/atlas/GUIBrainAtlas.m
+++ b/braph2/atlas/GUIBrainAtlas.m
@@ -773,6 +773,11 @@ init_contextmenus()
         
         % brain regions
         if get(ui_checkbox_figure_br, 'Value')
+            if ba.is_syms_empty() || ~isequal(ba.get_sym_length(), atlas.getBrainRegions().length() )
+                ba = atlas.getPlotBrainAtlas();
+                ba.br_syms()
+            end
+                
             ba.br_syms_on()
             for i = 1:1:atlas.getBrainRegions().length()
                 X = atlas.getBrainRegions().getValue(i).getX();

--- a/braph2/atlas/PlotBrainAtlas.m
+++ b/braph2/atlas/PlotBrainAtlas.m
@@ -712,6 +712,16 @@ classdef PlotBrainAtlas < PlotBrainSurf
                 end
             end
         end
+        function is_empty = is_syms_empty(ba)
+            if ~isempty(ba.syms)
+                is_empty = 0;
+            else
+                is_empty = 1;
+            end
+        end
+        function sym_length = get_sym_length(ba)
+            sym_length = length(ba.syms);
+        end
     end
     methods  % Functions spheres
         function h = br_sph(ba, i, varargin)


### PR DESCRIPTION
The new methods in PlotBrainRegion are like this, because maybe you dont want the handles to be public or have getters for the handles. I dont know, can solve in many ways.