### PR TITLE
468 ac bc tcomparison randommatrices

### DIFF
--- a/braph2/graph/measures/GlobalEfficiency.m
+++ b/braph2/graph/measures/GlobalEfficiency.m
@@ -8,7 +8,7 @@ classdef GlobalEfficiency < Measure
     % GlobalEfficiency methods:
     %   GlobalEfficiency            - constructor 
     %
-    % GlobalEfficiency methods (Static)
+    % GlobalEfficiency descriptive methods (Static)
     %   getClass                    - returns the global efficiency class
     %   getName                     - returns the name of global efficiency measure
     %   getDescription              - returns the description of global efficiency measure
@@ -55,11 +55,13 @@ classdef GlobalEfficiency < Measure
             for li = 1:1:L
                 inverse_distance = distance{li}.^-1;  % inverse distance
                 inverse_distance(1:N(li)+1:end) = 0;            
-                global_efficiency(li) = {(sum(inverse_distance, 2) / (N(li)-1))};   
+                global_efficiency_layer = (sum(inverse_distance, 2) / (N(li)-1));
+                global_efficiency_layer(isnan(global_efficiency_layer)) = 0;  % Should return zeros, not NaN
+                global_efficiency(li) = {global_efficiency_layer};  
             end
         end
     end
-    methods (Static)
+    methods (Static)  % Descriptive methods
         function measure_class = getClass()
             % GETCLASS returns the measure class 
             %            
@@ -127,7 +129,7 @@ classdef GlobalEfficiency < Measure
             % with GlobalEfficiency 
             %
             % LIST = GETCOMPATIBLEGRAPHLIST() returns a cell array 
-            % of compatible graph classes to GlobalEfficiency. 
+            % of compatible graph classes to global efficiency. 
             % The measure will not work if the graph is not compatible. 
             %
             % See also getCompatibleGraphNumber(). 
@@ -144,7 +146,7 @@ classdef GlobalEfficiency < Measure
             % graphs with GlobalEfficiency 
             %
             % N = GETCOMPATIBLEGRAPHNUMBER() returns the number of
-            % compatible graphs to GlobalEfficiency.
+            % compatible graphs to global efficiency.
             % 
             % See also getCompatibleGraphList().
             

--- a/braph2/graph/measures/GlobalEfficiencyAv.m
+++ b/braph2/graph/measures/GlobalEfficiencyAv.m
@@ -8,7 +8,7 @@ classdef GlobalEfficiencyAv < GlobalEfficiency
     % GlobalEfficiencyAv methods:
     %   GlobalEfficiencyAv          - constructor 
     %
-    % GlobalEfficiencyAv methods (Static)
+    % GlobalEfficiencyAv descriptive methods (Static)
     %   getClass                    - returns the average global efficiency class
     %   getName                     - returns the name of average global efficiency measure
     %   getDescription              - returns the description of average global efficiency measure
@@ -56,7 +56,7 @@ classdef GlobalEfficiencyAv < GlobalEfficiency
             end
         end
     end
-    methods (Static)
+    methods (Static)  % Descriptive methods
         function measure_class = getClass()
             % GETCLASS returns the measure class 
             %            

--- a/braph2/graph/measures/test_GlobalEfficiency.m
+++ b/braph2/graph/measures/test_GlobalEfficiency.m
@@ -107,16 +107,9 @@ assert(isequal(global_efficiency.getValue(), known_global_efficiency), ...
     'GlobalEfficiency is not being calculated correctly for MultiplexGraphWU.')
 
 %% Test 4: GraphBU: Calculation vs BCT
-graph_class = 'GraphBU';
-A = [
-    0   .1  0   0   0
-    .2   0  0   0   0
-    0    0  0  .2   0
-    0    0 .1   0   0
-    0    0  0   0   0
-    ];
-
+A = rand(randi(5));
 g = GraphBU(A);
+
 global_efficiency = GlobalEfficiency(g).getValue();
 global_efficiency = global_efficiency{1};
 global_efficiency_bct = efficiency_bin(g.getA());
@@ -184,7 +177,7 @@ else                                        %global efficiency
     E=sum(e(:))./(n^2-n);
 end
 
-
+E(isnan(E)) = 0;
     function D=distance_inv(A_)
         l=1;                                        %path length
         Lpath=A_;                                   %matrix of paths l

--- a/braph2/graph/measures/test_GlobalEfficiencyAv.m
+++ b/braph2/graph/measures/test_GlobalEfficiencyAv.m
@@ -107,16 +107,9 @@ assert(isequal(global_efficiency_av.getValue(), known_global_efficiency_av), ...
     'GlobalEfficiencyAv is not being calculated correctly for MultiplexGraphWU.')
 
 %% Test 4: GraphBU: Calculation vs BCT
-graph_class = 'GraphBU';
-A = [
-    0   .1  0   0   0
-    .2   0  0   0   0
-    0    0  0  .2   0
-    0    0 .1   0   0
-    0    0  0   0   0
-    ];
-
+A = rand(randi(5));
 g = GraphBU(A);
+
 global_efficiency_av = GlobalEfficiencyAv(g).getValue();
 global_efficiency_av = global_efficiency_av{1};
 global_efficiency_av_bct = efficiency_bin(g.getA());
@@ -184,7 +177,7 @@ else                                        %global efficiency
     E=sum(e(:))./(n^2-n);
 end
 
-
+E(isnan(E)) = 0;
     function D=distance_inv(A_)
         l=1;                                        %path length
         Lpath=A_;                                   %matrix of paths l

--- a/braph2/graph/measures/test_PathLength.m
+++ b/braph2/graph/measures/test_PathLength.m
@@ -121,13 +121,9 @@ assert(isequal(path_length.getValue(), known_path_length), ...
     'PathLength is not being calculated correctly for MultiplexGraphWU.')
 
 %% Test 5: Calculation subgraphs GraphWU vs BCT
-A = [
-    0   .1  0   0
-    .2   0 .1   0
-    0   .1  0  .2
-    0    0 .1   0
-    ];
+A = rand(randi(5));
 g = GraphWU(A);
+
 path_length = PathLength(g, 'PathLengthRule', 'subgraphs');
 path_length_value = path_length.getValue();
 path_length_value = path_length_value{1};
@@ -205,9 +201,10 @@ end
 Dv = D(~isnan(D));                  % get non-NaN indices of D
 
 % Mean of entries of D(G)
-% Modified version in order to get the first vector Emiliano Gomez
-
-lambda     = mean(Dv(1:3));  % 1:3 since function is ignoring diagonal and inf in this case
+% Modified version in order to get the first vector Emiliano Gomez, Anna Canal
+n = length(D);
+lambda     = mean(Dv(1:n-1));  % 1:3 since function is ignoring diagonal and inf in this case
+lambda(isnan(lambda)) = 0;
 
 % Efficiency: mean of inverse entries of D(G)
 efficiency = mean(1./Dv);


### PR DESCRIPTION
Updated tests from develop that have comparisons with BCT functions, and aren't using a random A:
- [x] Updated test_GlobalEfficiency.m and test_GlobalEfficiencyAv.m
- [x] Updated test_PathLength.m

