### PR TITLE
Bug in Save SubjectDTI.m

### DIFF
--- a/braph2/workflows/DTI/SubjectDTI.m
+++ b/braph2/workflows/DTI/SubjectDTI.m
@@ -304,8 +304,8 @@ classdef SubjectDTI < Subject
                     
                     % save
                     file = [root_directory filesep() cohort.getGroups().getValue(i).getID() filesep() id '.xlsx'];
-                    writematrix(label, file, 'Sheet', 1, 'Range', 'A1');
-                    writematrix(notes, file, 'Sheet', 1, 'Range', 'A2');
+                    writematrix(string(label), file, 'Sheet', 1, 'Range', 'A1');
+                    writematrix(string(notes), file, 'Sheet', 1, 'Range', 'A2');
                     writetable(tab, file, 'Sheet', 1, 'WriteVariableNames', 0, 'Range', 'A3');
                 end
             end

--- a/braph2/workflows/DTI/SubjectDTI.m
+++ b/braph2/workflows/DTI/SubjectDTI.m
@@ -269,7 +269,9 @@ classdef SubjectDTI < Subject
             
             % creates groups folders
             for i=1:1:cohort.getGroups().length()
-                mkdir(root_directory, cohort.getGroups().getValue(i).getID());
+                if ~exist([root_directory filesep() cohort.getGroups().getValue(i).getID()], 'dir')
+                    mkdir(root_directory, cohort.getGroups().getValue(i).getID());
+                end
                 
                 % cohort info
                 file_info_cohort = [root_directory filesep() 'cohort_info.txt'];


### PR DESCRIPTION
Might be a problem with version because with R2020a there is no errors or warnings in gv-cohort-final SubjectDTI.

I changed the data type of label and notes when creating a one-row table:
SubjectDTI.save_to_xls (line 307)
writematrix(string(label), file, 'Sheet', 1, 'Range', 'A1');
writematrix(string(notes), file, 'Sheet', 1, 'Range', 'A2');