### PR TITLE
712-ac-Eccentricity measures

### DIFF
--- a/braph2/graph/measures/Eccentricity.m
+++ b/braph2/graph/measures/Eccentricity.m
@@ -1,0 +1,183 @@
+classdef Eccentricity < Measure
+    % Eccentricity Eccentricity measure
+    % Eccentricity provides the eccentricity of a node for binary undirected
+    % (BU) and weighted undirected (WU) graphs. 
+    %
+    % It is calculated as the maximal shortest path length between a node
+    % and any other node within a layer.
+    % 
+    % Eccentricity methods:
+    %   Eccentricity                - constructor 
+    %
+    % Eccentricity descriptive methods (Static)
+    %   getClass                    - returns the eccentricity class
+    %   getName                     - returns the name of eccentricity measure
+    %   getDescription              - returns the description of eccentricity measure
+    %   getAvailableSettings        - returns the settings available to the class
+    %   getMeasureFormat            - returns the measure format
+    %   getMeasureScope             - returns the measure scope
+    %   getParametricity            - returns the parametricity of the measure  
+    %   getMeasure                  - returns the eccentricity class
+    %   getCompatibleGraphList      - returns a list of compatible graphs
+    %   getCompatibleGraphNumber    - returns the number of compatible graphs
+    %
+    % See also Measure, Distance, GraphBU, GraphWU, MultiplexGraphBU, MultiplexGraphWU.
+    
+    methods
+        function m = Eccentricity(g, varargin)
+            % ECCENTRICITY(G) creates eccentricity with default measure properties.
+            % G is a graph (e.g, an instance of GraphBU, GraphWU,
+            % MultiplexGraphBU, MultiplexGraphWU). 
+            %   
+            % ECCENTRICITY(G, 'EccentricityRule', ECCENTRICITYRULE) creates eccentricity 
+            % measure and initializes the property EccentricityRule with ECCENTRICITYRULE. 
+            % Admissible ECCENTRICITYRULE options are:
+            % ECCENTRICITYRULE = 'default' (default) - calculates ECCENTRICITY of global graph.
+            %                    'subgraphs' - calculates ECCENTRICITY within connected subgraphs.
+            %
+            % ECCENTRICITY(G, 'VALUE', VALUE) creates eccentricity, and sets the value
+            % to VALUE. G is a graph (e.g, an instance of GraphBU, GraphWU,
+            % MultiplexGraphBU, MultiplexGraphWU). 
+            %   
+            % See also Measure, Distance, GraphBU, GraphWU, MultiplexGraphBU, MultiplexGraphWU.
+
+            m = m@Measure(g, varargin{:});
+        end
+    end
+    methods (Access = protected)
+        function eccentricity = calculate(m)
+            % CALCULATE calculates the eccentricity value of a node
+            %
+            % ECCENTRICITY = CALCULATE(M) returns the value of the eccentricity of a
+            % node.
+            %
+            % See also Measure, Distance, GraphBU, GraphWU, MultiplexGraphBU, MultiplexGraphWU.
+            
+            g = m.getGraph();  % graph from measure class
+            L = g.layernumber();
+            
+            if g.is_measure_calculated('Distance')
+                D = g.getMeasure('Distance').getValue();
+            else
+                D = Distance(g, g.getSettings()).getValue();
+            end
+            
+            ecc_rule = get_from_varargin('default', 'EccentricityRule', m.getSettings());
+            eccentricity = cell(L, 1);
+            for li = 1:1:L
+                switch(ecc_rule)
+                    case {'subgraphs'}
+                        eccentricity(li)  = {max(D{li}.*(D{li}~=Inf), [], 2)}; 
+                    otherwise  % {'default'}
+                        eccentricity(li)  = {max(D{li}, [], 2)};
+                end    
+            end
+        end
+    end
+    methods (Static)
+        function measure_class = getClass()
+            % GETCLASS returns the measure class 
+            %            
+            % MEASURE_CLASS = GETCLASS() returns the class of the eccentricity measure.
+            %
+            % See also getName(), getDescription(). 
+            
+            measure_class = 'Eccentricity';
+        end
+        function name = getName()
+            % GETNAME returns the measure name
+            %
+            % NAME = GETNAME() returns the name of the eccentricity measure.
+            %
+            % See also getClass(), getDescription(). 
+            
+            name = 'Eccentricity';
+        end
+        function description = getDescription()
+            % GETDESCRIPTION returns the eccentricity description 
+            %
+            % DESCRIPTION = GETDESCRIPTION() returns the description of the
+            % eccentricity measure.
+            %
+            % See also getList(), getCompatibleGraphList().
+            
+            description = [ ...
+                'The Eccentricity of a node is ' ...
+                'the maximal shortest path length between a ' ...
+                'node and any other node within a layer.' ...
+                ];
+        end
+        function available_settings = getAvailableSettings()
+            % GETAVAILABLESETTINGS returns the setting available to Eccentricity
+            %
+            % AVAILABLESETTINGS = GETAVAILABLESETTINGS() returns the
+            % settings available to Eccentricity.
+            % ECCENTRICITYRULE = 'default' (default) - calculates ECCENTRICITY of global graph.
+            %                    'subgraphs' - calculates ECCENTRICITY within connected subgraphs.
+            % 
+            % See also getCompatibleGraphList()
+            
+            available_settings = {
+                'EccentricityRule', BRAPH2.STRING, 'default', {'default', 'subgraphs'};
+                };
+        end
+        function measure_format = getMeasureFormat()
+            % GETMEASUREFORMAT returns the measure format of Eccentricity
+            %
+            % MEASURE_FORMAT = GETMEASUREFORMAT() returns the measure format
+            % of eccentricity measure (NODAL).
+            %
+            % See also getMeasureScope.
+            
+            measure_format = Measure.NODAL;
+        end
+        function measure_scope = getMeasureScope()
+            % GETMEASURESCOPE returns the measure scope of Eccentricity
+            %
+            % MEASURE_SCOPE = GETMEASURESCOPE() returns the
+            % measure scope of eccentricity measure (UNILAYER).
+            %
+            % See also getMeasureFormat.
+            
+            measure_scope = Measure.UNILAYER;
+        end
+        function parametricity = getParametricity()
+            % GETPARAMETRICITY returns the parametricity of Eccentricity
+            %
+            % PARAMETRICITY = GETPARAMETRICITY() returns the
+            % parametricity of eccentricity measure (NONPARAMETRIC).
+            %
+            % See also getMeasureFormat, getMeasureScope.
+            
+            parametricity = Measure.NONPARAMETRIC;
+        end
+        function list = getCompatibleGraphList()
+            % GETCOMPATIBLEGRAPHLIST returns the list of compatible graphs
+            % with Eccentricity 
+            %
+            % LIST = GETCOMPATIBLEGRAPHLIST() returns a cell array 
+            % of compatible graph classes to eccentricity. 
+            % The measure will not work if the graph is not compatible. 
+            %
+            % See also getCompatibleGraphNumber(). 
+            
+            list = { ...
+                'GraphBU', ...
+                'GraphWU', ...
+                'MultiplexGraphBU', ...
+                'MultiplexGraphWU' ...
+                };
+        end
+        function n = getCompatibleGraphNumber()
+            % GETCOMPATIBLEGRAPHNUMBER returns the number of compatible
+            % graphs with Eccentricity 
+            %
+            % N = GETCOMPATIBLEGRAPHNUMBER() returns the number of
+            % compatible graphs to eccentricity.
+            % 
+            % See also getCompatibleGraphList().
+            
+            n = Measure.getCompatibleGraphNumber('Eccentricity');
+        end
+    end
+end

--- a/braph2/graph/measures/EccentricityAv.m
+++ b/braph2/graph/measures/EccentricityAv.m
@@ -1,0 +1,176 @@
+classdef EccentricityAv < Eccentricity
+    % EccentricityAv Average eccentricity measure
+    % EccentricityAv provides the average eccentricity of a graph for binary 
+    % undirected (BU) and weighted undirected (WU) graphs. 
+    % 
+    % It is calculated as the sum of the nodal eccentricities divided by 
+    % their number within a layer.
+    % 
+    % EccentricityAv methods:
+    %   EccentricityAv              - constructor
+    % 
+    % EccentricityAv methods (Static)
+    %   getClass                    - returns the average eccentricity class
+    %   getName                     - returns the name of average eccentricity measure
+    %   getDescription              - returns the description of average eccentricity measure
+    %   getAvailableSettings        - returns the settings available to the class
+    %   getMeasureFormat            - returns the measure format
+    %   getMeasureScope             - returns the measure scope
+    %   getParametricity            - returns the parametricity of the measure  
+    %   getMeasure                  - returns the average eccentricity class
+    %   getCompatibleGraphList      - returns a list of compatible graphs
+    %   getCompatibleGraphNumber    - returns the number of compatible graphs
+    %
+    % See also Measure, Eccentricity, Distance, GraphBU, GraphWU, MultiplexGraphBU, MultiplexGraphWU.
+    
+    methods
+        function m = EccentricityAv(g, varargin)
+            % ECCENTRICITYAV(G) creates average eccentricity with default
+            % Eccentricity properties.
+            % G is a graph (e.g, an instance of GraphBU, GraphWU,
+            % MultiplexGraphBU, MultiplexGraphWU). 
+            %   
+            % ECCENTRICITYAV(G, 'EccentricityRule', ECCENTRICITYRULE) creates average eccentricity 
+            % measure and initializes the property EccentricityRule with ECCENTRICITYRULE. 
+            % Admissible ECCENTRICITYRULE options are:
+            % ECCENTRICITYRULE = 'default' (default) - calculates ECCENTRICITY of global graph.
+            %                    'subgraphs' - calculates ECCENTRICITY within connected subgraphs.
+            %
+            % ECCENTRICITYAV(G, 'VALUE', VALUE) creates average eccentricity, and sets the value
+            % to VALUE. G is a graph (e.g, an instance of GraphBU, GraphWU,
+            % MultiplexGraphBU, MultiplexGraphWU). 
+            %
+            % See also Measure, Eccentricity, Distance, GraphBU, GraphWU, MultiplexGraphBU, MultiplexGraphWU.
+
+            m = m@Eccentricity(g, varargin{:});
+        end
+    end
+    methods (Access = protected)
+        function eccentricity_av = calculate(m)
+            % CALCULATE calculates the average eccentricity value of a
+            % graph
+            %
+            % ECCENTRICITYAV = CALCULATE(M) returns the value of the average eccentricity 
+            % of a graph.
+            %
+            % See also Measure, Eccentricity, Distance, GraphBU, GraphWU, MultiplexGraphBU, MultiplexGraphWU.
+            
+            g = m.getGraph();  % graph from measure class
+            
+            if g.is_measure_calculated('Eccentricity')
+                eccentricity = g.getMeasureValue('Eccentricity');
+            else
+                eccentricity = calculate@Eccentricity(m);
+            end
+                        
+            eccentricity_av = cell(g.layernumber(), 1);
+            for li = 1:1:length(eccentricity_av)
+                eccentricity_av(li) = {mean(eccentricity{li})};
+            end
+        end
+    end
+    methods (Static)
+        function measure_class = getClass()
+            % GETCLASS returns the measure class 
+            %            
+            % MEASURE_CLASS = GETCLASS() returns the class of the average eccentricity measure.
+            %
+            % See also getName(), getDescription(). 
+            
+            measure_class = 'EccentricityAv';
+        end
+        function name = getName()
+            % GETNAME returns the measure name
+            %
+            % NAME = GETNAME() returns the name of the average eccentricity measure.
+            %
+            % See also getClass(), getDescription(). 
+            
+            name = 'Average eccentricity';
+        end
+        function description = getDescription()
+            % GETDESCRIPTION returns the average eccentricity description 
+            %
+            % DESCRIPTION = GETDESCRIPTION() returns the description of the
+            % average eccentricity measure.
+            %
+            % See also getList(), getCompatibleGraphList().
+            
+            description = [ ...
+                'The average eccentricity of a graph is the ' ...
+                'sum of the nodal eccentricities divided by their number within a layer.' ...
+                ];
+        end
+        function available_settings = getAvailableSettings()
+            % GETAVAILABLESETTINGS returns the setting available to
+            % EccentricityAv
+            %
+            % AVAILABLESETTINGS = GETAVAILABLESETTINGS() returns the
+            % settings available to EccentricityAv.
+            % ECCENTRICITYRULE = 'default' (default) - calculates ECCENTRICITY of global graph.
+            %                    'subgraphs' - calculates ECCENTRICITY within connected subgraphs.
+            % 
+            % See also getCompatibleGraphList()
+            
+            available_settings = getAvailableSettings@Eccentricity();
+        end
+        function measure_format = getMeasureFormat()
+            % GETMEASUREFORMAT returns the measure format of EccentricityAv
+            %
+            % MEASURE_FORMAT = GETMEASUREFORMAT() returns the measure format
+            % of average eccentricity measure (GLOBAL).
+            %
+            % See also getMeasureScope.
+            
+            measure_format = Measure.GLOBAL;
+        end
+        function measure_scope = getMeasureScope()
+            % GETMEASURESCOPE returns the measure scope of EccentricityAv
+            %
+            % MEASURE_SCOPE = GETMEASURESCOPE() returns the
+            % measure scope of average eccentricity measure (UNILAYER).
+            %
+            % See also getMeasureFormat.
+            
+            measure_scope = Measure.UNILAYER;
+        end
+        function parametricity = getParametricity()
+            % GETPARAMETRICITY returns the parametricity of EccentricityAv
+            %
+            % PARAMETRICITY = GETPARAMETRICITY() returns the
+            % parametricity of average eccentricity measure (NONPARAMETRIC).
+            %
+            % See also getMeasureFormat, getMeasureScope.
+            
+            parametricity = Measure.NONPARAMETRIC;
+        end
+        function list = getCompatibleGraphList()
+            % GETCOMPATIBLEGRAPHLIST returns the list of compatible graphs
+            % with EccentricityAv 
+            %
+            % LIST = GETCOMPATIBLEGRAPHLIST() returns a cell array 
+            % of compatible graph classes to average eccentricity. 
+            % The measure will not work if the graph is not compatible. 
+            %
+            % See also getCompatibleGraphNumber(). 
+            
+            list = { ...
+                'GraphBU', ...
+                'GraphWU', ...
+                'MultiplexGraphBU', ...
+                'MultiplexGraphWU' ...
+                };
+        end
+        function n = getCompatibleGraphNumber()
+            % GETCOMPATIBLEGRAPHNUMBER returns the number of compatible
+            % graphs with EccentricityAv 
+            %
+            % N = GETCOMPATIBLEGRAPHNUMBER() returns the number of
+            % compatible graphs to average eccentricity.
+            % 
+            % See also getCompatibleGraphList().
+          
+            n = Measure.getCompatibleGraphNumber('EccentricityAv');
+        end
+    end
+end

--- a/braph2/graph/measures/InEccentricity.m
+++ b/braph2/graph/measures/InEccentricity.m
@@ -1,0 +1,182 @@
+classdef InEccentricity < Measure
+    % InEccentricity In-eccentricity measure
+    % InEccentricity provides the in-eccentricity of a node for binary directed
+    % (BD) and weighted directed (WD) graphs.
+    % 
+    % It is calculated as the maximal shortest in-path length between a node
+    % and any other node within a layer.
+    % 
+    % InEccentricity methods:
+    %   InEccentricity              - constructor
+    % 
+    % InEccentricity descriptive methods (Static)
+    %   getClass                    - returns the in-eccentricity class
+    %   getName                     - returns the name of in-eccentricity measure
+    %   getDescription              - returns the description of in-eccentricity measure
+    %   getAvailableSettings        - returns the settings available to the class
+    %   getMeasureFormat            - returns the measure format
+    %   getMeasureScope             - returns the measure scope
+    %   getParametricity            - returns the parametricity of the measure  
+    %   getMeasure                  - returns the in-eccentricity class
+    %   getCompatibleGraphList      - returns a list of compatible graphs
+    %   getCompatibleGraphNumber    - returns the number of compatible graphs
+    %
+    % See also Measure, Eccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.
+    methods
+        function m = InEccentricity(g, varargin)
+            % INECCENTRICITY(G) creates in-eccentricity with default measure properties.
+            % G is a graph (e.g, an instance of GraphBD, GraphWD,
+            % MultiplexGraphBD, MultiplexGraphWD). 
+            %   
+            % INECCENTRICITY(G, 'EccentricityRule', ECCENTRICITYRULE) creates in-eccentricity             
+            % measure and initializes the property EccentricityRule with ECCENTRICITYRULE. 
+            % Admissible RULE options are:
+            % ECCENTRICITYRULE = 'default' (default) - calculates INECCENTRICITY of global graph.
+            %                      'subgraphs' - calculates INECCENTRICITY within connected subgraphs.
+            %
+            % INECCENTRICITY(G, 'VALUE', VALUE) creates in-eccentricity, and sets the value
+            % to VALUE. G is a graph (e.g, an instance of GraphBD, GraphWD,
+            % MultiplexGraphBD, MultiplexGraphWD). 
+            %   
+            % See also Measure, Eccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.        
+           
+            m = m@Measure(g, varargin{:});
+        end
+    end
+    methods (Access = protected)
+        function in_eccentricity = calculate(m)
+            % CALCULATE calculates the in-eccentricity value of a node
+            %
+            % in-eccentricity = CALCULATE(M) returns the value of the in-eccentricity of a
+            % node.
+            %
+            % See also Measure, Eccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.
+            
+            g = m.getGraph();  % graph from measure class
+            L = g.layernumber();
+            
+            if g.is_measure_calculated('Distance')
+                D = g.getMeasure('Distance').getValue();
+            else
+                D = Distance(g, g.getSettings()).getValue();
+            end
+            
+            ecc_rule = get_from_varargin('default', 'EccentricityRule', m.getSettings());
+            in_eccentricity = cell(L, 1);
+            for li = 1:1:L
+                switch(ecc_rule)
+                    case {'subgraphs'}
+                        in_eccentricity(li)  = {max(D{li}.*(D{li}~=Inf), [], 1)'}; 
+                    otherwise  % {'default'}
+                        in_eccentricity(li)  = {max(D{li}, [], 1)'};
+                end    
+            end
+        end
+    end
+    methods (Static)
+        function measure_class = getClass()
+            % GETCLASS returns the measure class 
+            %            
+            % MEASURE_CLASS = GETCLASS() returns the class of the in-eccentricity measure.
+            %
+            % See also getName(), getDescription(). 
+            
+            measure_class = 'InEccentricity';
+        end
+        function name = getName()
+            % GETNAME returns the measure name
+            %
+            % NAME = GETNAME() returns the name of the in-eccentricity measure.
+            %
+            % See also getClass(), getDescription().
+            
+            name = 'In-eccentricity';
+        end
+        function description = getDescription()
+            % GETDESCRIPTION returns the in-eccentricity description 
+            %
+            % DESCRIPTION = GETDESCRIPTION() returns the description of the
+            % in-eccentricity measure.
+            %
+            % See also getList(), getCompatibleGraphList().
+            
+            description = [ ...
+                'The in-eccentricity of a node is ' ...
+                'the maximal shortest in-path length between a ' ...
+                'node and any other node within a layer.' ...
+                ];
+        end
+        function available_settings = getAvailableSettings()
+            % GETAVAILABLESETTINGS returns the setting available to InEccentricity
+            %
+            % AVAILABLESETTINGS = GETAVAILABLESETTINGS() returns the
+            % settings available to InEccentricity.
+            % ECCENTRICITYRULE = 'default' (default) - calculates INECCENTRICITY of global graph.
+            %                    'subgraphs' - calculates INECCENTRICITY within connected subgraphs.
+            % 
+            % See also getCompatibleGraphList()
+            
+            available_settings = {
+                'EccentricityRule', BRAPH2.STRING, 'default', {'default', 'subgraphs'};
+                };
+        end
+       function measure_format = getMeasureFormat()
+            % GETMEASUREFORMAT returns the measure format of InEccentricity
+            %
+            % MEASURE_FORMAT = GETMEASUREFORMAT() returns the measure format
+            % of in-eccentricity measure (NODAL).
+            %
+            % See also getMeasureScope.
+            
+            measure_format = Measure.NODAL;
+        end
+        function measure_scope = getMeasureScope()
+            % GETMEASURESCOPE returns the measure scope of InEccentricity
+            %
+            % MEASURE_SCOPE = GETMEASURESCOPE() returns the
+            % measure scope of in-eccentricity measure (UNILAYER).
+            %
+            % See also getMeasureFormat.
+            
+            measure_scope = Measure.UNILAYER;
+        end
+        function parametricity = getParametricity()
+            % GETPARAMETRICITY returns the parametricity of InEccentricity
+            %
+            % PARAMETRICITY = GETPARAMETRICITY() returns the
+            % parametricity of in-eccentricity measure (NONPARAMETRIC).
+            %
+            % See also getMeasureFormat, getMeasureScope.
+            
+            parametricity = Measure.NONPARAMETRIC;
+        end
+        function list = getCompatibleGraphList()
+            % GETCOMPATIBLEGRAPHLIST returns the list of compatible graphs
+            % with InEccentricity
+            %
+            % LIST = GETCOMPATIBLEGRAPHLIST() returns a cell array 
+            % of compatible graph classes to in-eccentricity. 
+            % The measure will not work if the graph is not compatible. 
+            %
+            % See also getCompatibleGraphNumber(). 
+            
+            list = { ...
+                'GraphBD', ...
+                'GraphWD', ...
+                'MultiplexGraphBD', ...
+                'MultiplexGraphWD' ...
+                };
+        end
+        function n = getCompatibleGraphNumber()
+            % GETCOMPATIBLEGRAPHNUMBER returns the number of compatible
+            % graphs with InEccentricity
+            %
+            % N = GETCOMPATIBLEGRAPHNUMBER() returns the number of
+            % compatible graphs to in-eccentricity.
+            % 
+            % See also getCompatibleGraphList().
+            
+            n = Measure.getCompatibleGraphNumber('InEccentricity');
+        end
+    end
+end

--- a/braph2/graph/measures/InEccentricityAv.m
+++ b/braph2/graph/measures/InEccentricityAv.m
@@ -115,30 +115,30 @@ classdef InEccentricityAv < InEccentricity
             available_settings = getAvailableSettings@InEccentricity();
         end
        function measure_format = getMeasureFormat()
-            % GETMEASUREFORMAT returns the measure format of InEccentricity
+            % GETMEASUREFORMAT returns the measure format of InEccentricityAv
             %
             % MEASURE_FORMAT = GETMEASUREFORMAT() returns the measure format
-            % of in-eccentricity measure (GLOBAL).
+            % of average in-eccentricity measure (GLOBAL).
             %
             % See also getMeasureScope.
             
             measure_format = Measure.GLOBAL;
         end
         function measure_scope = getMeasureScope()
-            % GETMEASURESCOPE returns the measure scope of InEccentricity
+            % GETMEASURESCOPE returns the measure scope of InEccentricityAv
             %
             % MEASURE_SCOPE = GETMEASURESCOPE() returns the
-            % measure scope of in-eccentricity measure (UNILAYER).
+            % measure scope of average in-eccentricity measure (UNILAYER).
             %
             % See also getMeasureFormat.
             
             measure_scope = Measure.UNILAYER;
         end
         function parametricity = getParametricity()
-            % GETPARAMETRICITY returns the parametricity of InEccentricity
+            % GETPARAMETRICITY returns the parametricity of InEccentricityAv
             %
             % PARAMETRICITY = GETPARAMETRICITY() returns the
-            % parametricity of in-eccentricity measure (NONPARAMETRIC).
+            % parametricity of average in-eccentricity measure (NONPARAMETRIC).
             %
             % See also getMeasureFormat, getMeasureScope.
             

--- a/braph2/graph/measures/InEccentricityAv.m
+++ b/braph2/graph/measures/InEccentricityAv.m
@@ -1,0 +1,176 @@
+classdef InEccentricityAv < InEccentricity
+    % InEccentricityAv Average in-eccentricity measure
+    % InEccentricityAv provides the average in-eccentricity of a graph for binary 
+    % directed (BD) and weighted directed (WD) graphs. 
+    %
+    % It is calculated as the sum of the nodal in-eccentricities divided by 
+    % their number within a layer
+    %
+    % InEccentricityAv methods:
+    %   InEccentricityAv            - constructor      
+    % 
+    % InEccentricityAv descriptive methods (Static)
+    %   getClass                    - returns the average in-eccentricity class
+    %   getName                     - returns the name of average in-eccentricity measure
+    %   getDescription              - returns the description of average in-eccentricity measure
+    %   getAvailableSettings        - returns the settings available to the class
+    %   getMeasureFormat            - returns the measure format
+    %   getMeasureScope             - returns the measure scope
+    %   getParametricity            - returns the parametricity of the measure  
+    %   getMeasure                  - returns the average in-eccentricity class
+    %   getCompatibleGraphList      - returns a list of compatible graphs
+    %   getCompatibleGraphNumber    - returns the number of compatible graphs
+    %
+    % See also Measure, EccentricityAv, InEccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.
+    
+    methods
+        function m = InEccentricityAv(g, varargin)
+            % INECCENTRICITYAV(G) creates average in-eccentricity with default
+            % InEccentricity properties.
+            % G is a graph (e.g, an instance of GraphBD, GraphBU,
+            % GraphWD, Graph WU). 
+            %   
+            % INECCENTRICITYAV(G, 'InEccentricityRule', INECCENTRICITYRULE) creates average in-eccentricity 
+            % measure and initializes the property InEccentricityRule with INECCENTRICITYRULE. 
+            % Admissible INECCENTRICITYRULE options are:
+            % INECCENTRICITYRULE = 'default' (default) - calculates ECCENTRICITY of global graph.
+            %                    'subgraphs' - calculates ECCENTRICITY within connected subgraphs.
+            %
+            % INECCENTRICITYAV(G, 'VALUE', VALUE) creates average eccentricity, and sets the value
+            % to VALUE. G is a graph (e.g, an instance of GraphBD, GraphBU,
+            % GraphWD, Graph WU).
+            %   
+            % See also Measure, EccentricityAv, InEccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.
+
+            m = m@InEccentricity(g, varargin{:});
+        end
+    end
+    methods (Access = protected)
+        function in_eccentricity_av = calculate(m)
+            % CALCULATE calculates the average in-eccentricity value of a
+            % graph
+            %
+            % ECCENTRICITYAV = CALCULATE(M) returns the value of the average in-eccentricity 
+            % of a graph.
+            %
+            % See also Measure, EccentricityAv, InEccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.
+            
+            g = m.getGraph();  % graph from measure class
+            
+            if g.is_measure_calculated('InEccentricity')
+                in_eccentricity = g.getMeasureValue('InEccentricity');
+            else
+                in_eccentricity = calculate@InEccentricity(m);
+            end
+
+            in_eccentricity_av = cell(g.layernumber(), 1);
+            for li = 1:1:length(in_eccentricity_av)
+                in_eccentricity_av(li) = {mean(in_eccentricity{li})};
+            end
+        end
+    end
+    methods (Static)
+        function measure_class = getClass()
+            % GETCLASS returns the measure class 
+            %            
+            % MEASURE_CLASS = GETCLASS() returns the class of the average in-eccentricity measure.
+            %
+            % See also getName(), getDescription(). 
+            
+            measure_class = 'InEccentricityAv';
+        end
+        function name = getName()
+            % GETNAME returns the measure name
+            %
+            % NAME = GETNAME() returns the name of the average in-eccentricity measure.
+            %
+            % See also getClass(), getDescription(). 
+            
+            name = 'Average in-eccentricity';
+        end
+        function description = getDescription()
+            % GETDESCRIPTION returns the average in-eccentricity description 
+            %
+            % DESCRIPTION = GETDESCRIPTION() returns the description of the
+            % average in-eccentricity measure.
+            %
+            % See also getList(), getCompatibleGraphList().
+            
+            description = [ ...
+                'The average in-eccentricity of a graph is the' ...
+                'sum of the nodal in-eccentricities divided by their number within a layer.' ...
+                ];
+        end
+        function available_settings = getAvailableSettings()
+            % GETAVAILABLESETTINGS returns the setting available to
+            % InEccentricityAv
+            %
+            % AVAILABLESETTINGS = GETAVAILABLESETTINGS() returns the
+            % settings available to InEccentricityAv.
+            % ECCENTRICITYRULE = 'default' (default) - calculates INECCENTRICITY of global graph.
+            %                    'subgraphs' - calculates INECCENTRICITY within connected subgraphs.
+            % 
+            % See also getCompatibleGraphList()
+           
+            available_settings = getAvailableSettings@InEccentricity();
+        end
+       function measure_format = getMeasureFormat()
+            % GETMEASUREFORMAT returns the measure format of InEccentricity
+            %
+            % MEASURE_FORMAT = GETMEASUREFORMAT() returns the measure format
+            % of in-eccentricity measure (GLOBAL).
+            %
+            % See also getMeasureScope.
+            
+            measure_format = Measure.GLOBAL;
+        end
+        function measure_scope = getMeasureScope()
+            % GETMEASURESCOPE returns the measure scope of InEccentricity
+            %
+            % MEASURE_SCOPE = GETMEASURESCOPE() returns the
+            % measure scope of in-eccentricity measure (UNILAYER).
+            %
+            % See also getMeasureFormat.
+            
+            measure_scope = Measure.UNILAYER;
+        end
+        function parametricity = getParametricity()
+            % GETPARAMETRICITY returns the parametricity of InEccentricity
+            %
+            % PARAMETRICITY = GETPARAMETRICITY() returns the
+            % parametricity of in-eccentricity measure (NONPARAMETRIC).
+            %
+            % See also getMeasureFormat, getMeasureScope.
+            
+            parametricity = Measure.NONPARAMETRIC;
+        end
+        function list = getCompatibleGraphList()
+            % GETCOMPATIBLEGRAPHLIST returns the list of compatible graphs
+            % with InEccentricityAv 
+            %
+            % LIST = GETCOMPATIBLEGRAPHLIST() returns a cell array 
+            % of compatible graph classes to average in-eccentricity. 
+            % The measure will not work if the graph is not compatible. 
+            %
+            % See also getCompatibleGraphNumber(). 
+            
+            list = { ...
+                'GraphBD', ...
+                'GraphWD', ...
+                'MultiplexGraphBD', ...
+                'MultiplexGraphWD' ...
+                };
+        end
+        function n = getCompatibleGraphNumber()
+            % GETCOMPATIBLEGRAPHNUMBER returns the number of compatible
+            % graphs with InEccentricityAv 
+            %
+            % N = GETCOMPATIBLEGRAPHNUMBER() returns the number of
+            % compatible graphs to average in-eccentricity.
+            % 
+            % See also getCompatibleGraphList().
+          
+            n = Measure.getCompatibleGraphNumber('InEccentricityAv');
+        end
+    end
+end

--- a/braph2/graph/measures/OutEccentricity.m
+++ b/braph2/graph/measures/OutEccentricity.m
@@ -1,54 +1,54 @@
-classdef InEccentricity < Measure
-    % InEccentricity In-eccentricity measure
-    % InEccentricity provides the in-eccentricity of a node for binary directed
-    % (BD) and weighted directed (WD) graphs.
-    % 
-    % It is calculated as the maximal shortest in-path length between a node
+classdef OutEccentricity < Measure
+    % OutEccentricity Out-eccentricity measure
+    % OutEccentricity provides the out-eccentricity of a node for binary directed
+    % (BD) and weighted directed (WD) graphs. 
+    %
+    % It is calculated as the maximal shortest out-path length between a node
     % and any other node within a layer.
     % 
-    % InEccentricity methods:
-    %   InEccentricity              - constructor
+    % OutEccentricity methods:
+    %   OutEccentricity             - constructor 
     % 
-    % InEccentricity descriptive methods (Static)
-    %   getClass                    - returns the in-eccentricity class
-    %   getName                     - returns the name of in-eccentricity measure
-    %   getDescription              - returns the description of in-eccentricity measure
+    % OutEccentricity methods (Static)
+    %   getClass                    - returns the out-eccentricity class
+    %   getName                     - returns the name of out-eccentricity measure
+    %   getDescription              - returns the description of out-eccentricity measure
     %   getAvailableSettings        - returns the settings available to the class
     %   getMeasureFormat            - returns the measure format
     %   getMeasureScope             - returns the measure scope
     %   getParametricity            - returns the parametricity of the measure  
-    %   getMeasure                  - returns the in-eccentricity class
+    %   getMeasure                  - returns the out-eccentricity class
     %   getCompatibleGraphList      - returns a list of compatible graphs
     %   getCompatibleGraphNumber    - returns the number of compatible graphs
     %
     % See also Measure, Eccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.
     
     methods
-        function m = InEccentricity(g, varargin)
-            % INECCENTRICITY(G) creates in-eccentricity with default measure properties.
+        function m = OutEccentricity(g, varargin)
+            % OUTECCENTRICITY(G) creates out-eccentricity with default measure properties.
             % G is a graph (e.g, an instance of GraphBD, GraphWD,
             % MultiplexGraphBD, MultiplexGraphWD). 
             %   
-            % INECCENTRICITY(G, 'EccentricityRule', ECCENTRICITYRULE) creates in-eccentricity             
+            % OUTECCENTRICITY(G, 'EccentricityRule', ECCENTRICITIRULE) creates out-eccentricity 
             % measure and initializes the property EccentricityRule with ECCENTRICITYRULE. 
             % Admissible RULE options are:
-            % ECCENTRICITYRULE = 'default' (default) - calculates INECCENTRICITY of global graph.
-            %                      'subgraphs' - calculates INECCENTRICITY within connected subgraphs.
+            % ECCENTRICITYRULE = 'default' (default) - calculates OUTECCENTRICITY of global graph.
+            %                       'subgraphs' - calculates OUTECCENTRICITY within connected subgraphs.
             %
-            % INECCENTRICITY(G, 'VALUE', VALUE) creates in-eccentricity, and sets the value
+            % OUTECCENTRICITY(G, 'VALUE', VALUE) creates out-eccentricity, and sets the value
             % to VALUE. G is a graph (e.g, an instance of GraphBD, GraphWD,
             % MultiplexGraphBD, MultiplexGraphWD). 
             %   
-            % See also Measure, Eccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.        
-           
+            % See also Measure, Eccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.
+            
             m = m@Measure(g, varargin{:});
         end
     end
     methods (Access = protected)
-        function in_eccentricity = calculate(m)
-            % CALCULATE calculates the in-eccentricity value of a node
+        function out_eccentricity = calculate(m)
+            % CALCULATE calculates the out-eccentricity value of a node
             %
-            % in-eccentricity = CALCULATE(M) returns the value of the in-eccentricity of a
+            % out-eccentricity = CALCULATE(M) returns the value of the out-eccentricity of a
             % node.
             %
             % See also Measure, Eccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.
@@ -63,13 +63,13 @@ classdef InEccentricity < Measure
             end
             
             ecc_rule = get_from_varargin('default', 'EccentricityRule', m.getSettings());
-            in_eccentricity = cell(L, 1);
+            out_eccentricity = cell(L, 1);
             for li = 1:1:L
                 switch(ecc_rule)
                     case {'subgraphs'}
-                        in_eccentricity(li)  = {max(D{li}.*(D{li}~=Inf), [], 1)'}; 
+                        out_eccentricity(li)  = {max(D{li}.*(D{li}~=Inf), [], 2)}; 
                     otherwise  % {'default'}
-                        in_eccentricity(li)  = {max(D{li}, [], 1)'};
+                        out_eccentricity(li)  = {max(D{li}, [], 2)};
                 end    
             end
         end
@@ -78,42 +78,41 @@ classdef InEccentricity < Measure
         function measure_class = getClass()
             % GETCLASS returns the measure class 
             %            
-            % MEASURE_CLASS = GETCLASS() returns the class of the in-eccentricity measure.
+            % MEASURE_CLASS = GETCLASS() returns the class of the out-eccentricity measure.
             %
             % See also getName(), getDescription(). 
-            
-            measure_class = 'InEccentricity';
+            measure_class = 'OutEccentricity';
         end
         function name = getName()
             % GETNAME returns the measure name
             %
-            % NAME = GETNAME() returns the name of the in-eccentricity measure.
+            % NAME = GETNAME() returns the name of the out-eccentricity measure.
             %
             % See also getClass(), getDescription().
             
-            name = 'In-eccentricity';
+            name = 'Out-eccentricity';
         end
         function description = getDescription()
-            % GETDESCRIPTION returns the in-eccentricity description 
+            % GETDESCRIPTION returns the out-eccentricity description 
             %
             % DESCRIPTION = GETDESCRIPTION() returns the description of the
-            % in-eccentricity measure.
+            % out-eccentricity measure.
             %
             % See also getList(), getCompatibleGraphList().
             
             description = [ ...
-                'The in-eccentricity of a node is ' ...
-                'the maximal shortest in-path length between a ' ...
+                'The out-eccentricity of a node is ' ...
+                'the maximal shortest out-path length between a ' ...
                 'node and any other node within a layer.' ...
                 ];
         end
         function available_settings = getAvailableSettings()
-            % GETAVAILABLESETTINGS returns the setting available to InEccentricity
+            % GETAVAILABLESETTINGS returns the setting available to OutEccentricity
             %
             % AVAILABLESETTINGS = GETAVAILABLESETTINGS() returns the
-            % settings available to InEccentricity.
-            % ECCENTRICITYRULE = 'default' (default) - calculates INECCENTRICITY of global graph.
-            %                    'subgraphs' - calculates INECCENTRICITY within connected subgraphs.
+            % settings available to OutEccentricityRule. 
+            % ECCENTRICITYRULE = 'default' (default) - calculates OUTECCENTRICITY of global graph.
+            %                       'subgraphs' - calculates OUTECCENTRICITY within connected subgraphs.
             % 
             % See also getCompatibleGraphList()
             
@@ -122,30 +121,30 @@ classdef InEccentricity < Measure
                 };
         end
        function measure_format = getMeasureFormat()
-            % GETMEASUREFORMAT returns the measure format of InEccentricity
+            % GETMEASUREFORMAT returns the measure format of OutEccentricity
             %
             % MEASURE_FORMAT = GETMEASUREFORMAT() returns the measure format
-            % of in-eccentricity measure (NODAL).
+            % of out-eccentricity measure (NODAL).
             %
             % See also getMeasureScope.
             
             measure_format = Measure.NODAL;
         end
         function measure_scope = getMeasureScope()
-            % GETMEASURESCOPE returns the measure scope of InEccentricity
+            % GETMEASURESCOPE returns the measure scope of OutEccentricity
             %
             % MEASURE_SCOPE = GETMEASURESCOPE() returns the
-            % measure scope of in-eccentricity measure (UNILAYER).
+            % measure scope of out-eccentricity measure (UNILAYER).
             %
             % See also getMeasureFormat.
             
             measure_scope = Measure.UNILAYER;
         end
         function parametricity = getParametricity()
-            % GETPARAMETRICITY returns the parametricity of InEccentricity
+            % GETPARAMETRICITY returns the parametricity of OutEccentricity
             %
             % PARAMETRICITY = GETPARAMETRICITY() returns the
-            % parametricity of in-eccentricity measure (NONPARAMETRIC).
+            % parametricity of out-eccentricity measure (NONPARAMETRIC).
             %
             % See also getMeasureFormat, getMeasureScope.
             
@@ -153,10 +152,10 @@ classdef InEccentricity < Measure
         end
         function list = getCompatibleGraphList()
             % GETCOMPATIBLEGRAPHLIST returns the list of compatible graphs
-            % with InEccentricity
+            % with OutEccentricity
             %
             % LIST = GETCOMPATIBLEGRAPHLIST() returns a cell array 
-            % of compatible graph classes to in-eccentricity. 
+            % of compatible graph classes to out-eccentricity. 
             % The measure will not work if the graph is not compatible. 
             %
             % See also getCompatibleGraphNumber(). 
@@ -170,14 +169,14 @@ classdef InEccentricity < Measure
         end
         function n = getCompatibleGraphNumber()
             % GETCOMPATIBLEGRAPHNUMBER returns the number of compatible
-            % graphs with InEccentricity
+            % graphs with OutEccentricity
             %
             % N = GETCOMPATIBLEGRAPHNUMBER() returns the number of
-            % compatible graphs to in-eccentricity.
+            % compatible graphs to out-eccentricity.
             % 
             % See also getCompatibleGraphList().
             
-            n = Measure.getCompatibleGraphNumber('InEccentricity');
+            n = Measure.getCompatibleGraphNumber('OutEccentricity');
         end
     end
 end

--- a/braph2/graph/measures/OutEccentricity.m
+++ b/braph2/graph/measures/OutEccentricity.m
@@ -9,7 +9,7 @@ classdef OutEccentricity < Measure
     % OutEccentricity methods:
     %   OutEccentricity             - constructor 
     % 
-    % OutEccentricity methods (Static)
+    % OutEccentricity descriptive methods (Static)
     %   getClass                    - returns the out-eccentricity class
     %   getName                     - returns the name of out-eccentricity measure
     %   getDescription              - returns the description of out-eccentricity measure

--- a/braph2/graph/measures/OutEccentricityAv.m
+++ b/braph2/graph/measures/OutEccentricityAv.m
@@ -1,0 +1,175 @@
+classdef OutEccentricityAv < OutEccentricity
+    % OutEccentricityAv Average out-eccentricity measure
+    % OutEccentricityAv provides the average out-eccentricity of a graph for binary 
+    % directed (BD) and weighted directed (WD) graphs. 
+    %
+    % It is calculated as the sum of the nodal out-eccentricities divided by 
+    % their number within a layer
+    % 
+    % OutEccentricityAv methods:
+    %   OutEccentricityAv           - constructor 
+    % 
+    % OutEccentricityAv descriptive methods (Static)
+    %   getClass                    - returns the average out-eccentricity class
+    %   getName                     - returns the name of average out-eccentricity measure
+    %   getDescription              - returns the description of average out-eccentricity measure
+    %   getAvailableSettings        - returns the settings available to the class
+    %   getAvailableSettings        - returns the settings available to the class
+    %   getMeasureFormat            - returns the measure format
+    %   getMeasureScope             - returns the measure scope
+    %   getMeasure                  - returns the average out-eccentricity class
+    %   getCompatibleGraphList      - returns a list of compatible graphs
+    %   getCompatibleGraphNumber    - returns the number of compatible graphs
+    %
+    % See also Measure, EccentricityAv, OutEccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.
+    
+    methods
+        function m = OutEccentricityAv(g, varargin)
+            % OUTECCENTRICITYAV(G) creates average out-eccentricity with default
+            % OutEccentricity properties.
+            % G is a graph (e.g, an instance of GraphBD, GraphBU,
+            % GraphWD, Graph WU). 
+            %   
+            % OUTECCENTRICITYAV(G, 'EccentricityRule', ECCENTRICITYRULE) creates average out-eccentricity 
+            % measure and initializes the property EccentricityRule with ECCENTRICITYRULE. 
+            % Admissible RULE options are:
+            % ECCENTRICITYRULE = 'default' (default) - calculates OUTECCENTRICITY of global graph.
+            %                    'subgraphs' - calculates OUTECCENTRICITY within connected subgraphs.
+            %
+            % OUTECCENTRICITYAV(G, 'VALUE', VALUE) creates average out-eccentricity, and sets the value
+            % to VALUE. G is a graph (e.g, an instance of GraphBD, GraphBU,
+            % GraphWD, Graph WU). 
+            %   
+            % See also Measure, EccentricityAv, OutEccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.
+            
+            m = m@OutEccentricity(g, varargin{:});
+        end
+    end
+    methods (Access = protected)
+        function out_eccentricity_av = calculate(m)
+            % CALCULATE calculates the average out-eccentricity value of a
+            % graph
+            %
+            % OUTECCENTRICITYAV = CALCULATE(M) returns the value of the average out-eccentricity 
+            % of a graph.
+            %
+            % See also Measure, EccentricityAv, OutEccentricity, Distance, GraphBD, GraphWD, MultiplexGraphBD, MultiplexGraphWD.
+            
+            g = m.getGraph();  % graph from measure class
+            
+            if g.is_measure_calculated('OutEccentricity')
+                out_eccentricity = g.getMeasureValue('OutEccentricity');
+            else
+                out_eccentricity = calculate@OutEccentricity(m);
+            end
+
+            out_eccentricity_av = cell(g.layernumber(), 1);
+            for li = 1:1:length(out_eccentricity_av)
+                out_eccentricity_av(li) = {mean(out_eccentricity{li})};
+            end
+        end
+    end
+    methods (Static)
+        function measure_class = getClass()
+            % GETCLASS returns the measure class 
+            %            
+            % MEASURE_CLASS = GETCLASS() returns the class of the average out-eccentricity measure.
+            %
+            % See also getName(), getDescription(). 
+            
+            measure_class = 'OutEccentricityAv';
+        end
+        function name = getName()
+            % GETNAME returns the measure name
+            %
+            % NAME = GETNAME() returns the name of the average out-eccentricity measure.
+            %
+            % See also getClass(), getDescription(). 
+            
+            name = 'Average out-eccentricity';
+        end
+        function description = getDescription()
+            % GETDESCRIPTION returns the average out-eccentricity description 
+            %
+            % DESCRIPTION = GETDESCRIPTION() returns the description of the
+            % average out-eccentricity measure.
+            %
+            % See also getList(), getCompatibleGraphList().
+            
+            description = [ ...
+                'The average out-eccentricity of a graph is the' ...
+                'sum of the nodal out Eccentricities divided by their number within a layer.' ...
+                ];
+        end
+        function available_settings = getAvailableSettings()   
+            % GETAVAILABLESETTINGS returns the setting available to OutEccentricityAv
+            %
+            % AVAILABLESETTINGS = GETAVAILABLESETTINGS() returns the
+            % settings available to OutEccentricityAv.
+            % ECCENTRICITYRULE = 'default' (default) - calculates OUTECCENTRICITY of global graph.
+            %                    'subgraphs' - calculates OUTECCENTRICITY within connected subgraphs.
+            % 
+            % See also getCompatibleGraphList()
+           
+            available_settings = getAvailableSettings@OutEccentricity();
+        end
+       function measure_format = getMeasureFormat()
+            % GETMEASUREFORMAT returns the measure format of OutEccentricityAv
+            %
+            % MEASURE_FORMAT = GETMEASUREFORMAT() returns the measure format
+            % of average out-eccentricity measure (GLOBAL).
+            %
+            % See also getMeasureScope.
+            
+            measure_format = Measure.GLOBAL;
+        end
+        function measure_scope = getMeasureScope()
+            % GETMEASURESCOPE returns the measure scope of OutEccentricityAv
+            %
+            % MEASURE_SCOPE = GETMEASURESCOPE() returns the
+            % measure scope of average out-eccentricity measure (UNILAYER).
+            %
+            % See also getMeasureFormat.
+            
+            measure_scope = Measure.UNILAYER;
+        end
+        function parametricity = getParametricity()
+            % GETPARAMETRICITY returns the parametricity of OutEccentricityAv
+            %
+            % PARAMETRICITY = GETPARAMETRICITY() returns the
+            % parametricity of average out-eccentricity measure (NONPARAMETRIC).
+            %
+            % See also getMeasureFormat, getMeasureScope.
+            
+            parametricity = Measure.NONPARAMETRIC;
+        end
+        function list = getCompatibleGraphList()
+            % GETCOMPATIBLEGRAPHLIST returns the list of compatible graphs
+            % with OutEccentricityAv 
+            %
+            % LIST = GETCOMPATIBLEGRAPHLIST() returns a cell array 
+            % of compatible graph classes to average out-eccentricity.
+            % The measure will not work if the graph is not compatible. 
+            %
+            % See also getCompatibleGraphNumber(). 
+            
+            list = { ...
+                'GraphBD', ...
+                'GraphWD', ...
+                'MultiplexGraphBD', ...
+                'MultiplexGraphWD' ...
+                };
+        end
+        function n = getCompatibleGraphNumber()
+            % GETCOMPATIBLEGRAPHNUMBER returns the number of compatible
+            % graphs with OutEccentricityAv 
+            %
+            % N = GETCOMPATIBLEGRAPHNUMBER() returns the number of
+            % compatible graphs to average out-eccentricity.
+            % 
+            % See also getCompatibleGraphList().
+          
+            n = Measure.getCompatibleGraphNumber('OutEccentricityAv');
+        end
+    end
+end

--- a/braph2/graph/measures/test_Eccentricity.m
+++ b/braph2/graph/measures/test_Eccentricity.m
@@ -1,0 +1,244 @@
+% test Eccentricity
+
+%% Test 1: GraphBU
+A = [
+    0     .1  .2  .25  0;
+    .125  0   0   0    0;
+    .2    .5  0   .25  0;
+    .125  10  0   0    0;
+    0     0   0   0    0
+    ];
+    
+known_eccentricity_subgraphs = {[1 1 1 1 0]'};
+
+g = GraphBU(A);
+eccentricity = Eccentricity(g, 'EccentricityRule', 'subgraphs');
+
+assert(isequal(eccentricity.getValue(), known_eccentricity_subgraphs), ...
+    [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
+    'Eccentricity is not being calculated correctly for GraphBU.')
+
+known_eccentricity_default = {[Inf Inf Inf Inf Inf]'};
+
+eccentricity = Eccentricity(g);
+
+assert(isequal(eccentricity.getValue(), known_eccentricity_default), ...
+    [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
+    'Eccentricity is not being calculated correctly for GraphBU.')
+
+%% Test 2: GraphWU
+A = [
+    0     .1  .2  .25  0;
+    .125  0   0   0    0;
+    .2    .5  0   .25  0;
+    .125  10  0   0    0;
+    0     0   0   0    0
+    ];
+    
+known_eccentricity_subgraphs = {[5 5 5 4 0]'};
+
+g = GraphWU(A);
+eccentricity = Eccentricity(g, 'EccentricityRule', 'subgraphs');
+
+assert(isequal(eccentricity.getValue(), known_eccentricity_subgraphs), ...
+    [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
+    'Eccentricity is not being calculated correctly for GraphWU.')
+
+known_eccentricity_default = {[Inf Inf Inf Inf Inf]'};
+
+eccentricity = Eccentricity(g);
+
+assert(isequal(eccentricity.getValue(), known_eccentricity_default), ...
+    [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
+    'Eccentricity is not being calculated correctly for GraphWU.')
+
+%% Test 3: MultiplexGraphBU
+A11 = [
+    0     .1  .2  .25  0;
+    .125  0   0   0    0;
+    .2    .5  0   .25  0;
+    .125  10  0   0    0;
+    0     0   0   0    0
+    ];
+A12 = eye(5);
+A21 = eye(5);
+A22 = [
+    0     .1  .2  .25  0;
+    .125  0   0   0    0;
+    .2    .5  0   .25  0;
+    .125  10  0   0    0;
+    0     0   0   0    0
+    ];
+
+A = {
+    A11     A12
+    A21     A22
+    };
+
+known_eccentricity_subgraphs = {
+                                [1 1 1 1 0]'
+                                [1 1 1 1 0]'
+                                };
+
+g = MultiplexGraphBU(A);
+eccentricity = Eccentricity(g, 'EccentricityRule', 'subgraphs');
+
+assert(isequal(eccentricity.getValue(), known_eccentricity_subgraphs), ...
+    [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
+    'Eccentricity is not being calculated correctly for MultiplexGraphBU.')
+
+known_eccentricity_default = {
+                              [Inf Inf Inf Inf Inf]'
+                              [Inf Inf Inf Inf Inf]'
+                              };
+
+eccentricity = Eccentricity(g);
+
+assert(isequal(eccentricity.getValue(), known_eccentricity_default), ...
+    [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
+    'Eccentricity is not being calculated correctly for MultiplexGraphBU.')
+
+%% Test 4: MultiplexGraphWU
+A11 = [
+    0     .1  .2  .25  0;
+    .125  0   0   0    0;
+    .2    .5  0   .25  0;
+    .125  10  0   0    0;
+    0     0   0   0    0
+    ];
+A12 = eye(5);
+A21 = eye(5);
+A22 = [
+    0     .1  .2  .25  0;
+    .125  0   0   0    0;
+    .2    .5  0   .25  0;
+    .125  10  0   0    0;
+    0     0   0   0    0
+    ];
+
+A = {
+    A11     A12
+    A21     A22
+    };
+
+known_eccentricity_subgraphs = {
+                                [5 5 5 4 0]'
+                                [5 5 5 4 0]'
+                                };
+
+g = MultiplexGraphWU(A);
+eccentricity = Eccentricity(g, 'EccentricityRule', 'subgraphs');
+
+assert(isequal(eccentricity.getValue(), known_eccentricity_subgraphs), ...
+    [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
+    'Eccentricity is not being calculated correctly for MultiplexGraphWU.')
+
+known_eccentricity_default = {
+                              [Inf Inf Inf Inf Inf]'
+                              [Inf Inf Inf Inf Inf]'
+                              };
+
+eccentricity = Eccentricity(g);
+
+assert(isequal(eccentricity.getValue(), known_eccentricity_default), ...
+    [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
+    'Eccentricity is not being calculated correctly for MultiplexGraphWU.')
+
+%% Test 5: Calculation WU subgraphs vs BCT
+A = rand(randi(5));
+g = Graph.getGraph('GraphWU', A);
+%g = GraphWU(A);
+eccentricity = Eccentricity(g, 'EccentricityRule', 'subgraphs').getValue();
+
+distance = Distance(g).getValue();
+[~, ~, eccentricity_bct, ~, ~]= charpath(distance{1});
+eccentricity = eccentricity{1};
+
+assert(isequal( round(eccentricity(1), 3), round(eccentricity_bct, 3)), ...
+        [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
+        'Eccentricity is not being calculated correctly for BCT.')
+
+%% Functions to calculate Eccentricity from 2019_03_03_BCT
+function  [lambda,efficiency,ecc,radius,diameter] = charpath(D,diagonal_dist,infinite_dist)
+%CHARPATH       Characteristic path length, global efficiency and related statistics
+%
+%   lambda                                  = charpath(D);
+%   lambda                                  = charpath(D);
+%   [lambda,efficiency]                     = charpath(D);
+%   [lambda,efficiency,ecc,radius,diameter] = charpath(D,diagonal_dist,infinite_dist);
+%
+%   The network characteristic path length is the average shortest path
+%   length between all pairs of nodes in the network. The global efficiency
+%   is the average inverse shortest path length in the network. The nodal
+%   eccentricity is the maximal path length between a node and any other
+%   node in the network. The radius is the minimal eccentricity, and the
+%   diameter is the maximal eccentricity.
+%
+%   Input:      D,              distance matrix
+%               diagonal_dist   optional argument
+%                               include distances on the main diagonal
+%                                   (default: diagonal_dist=0)
+%               infinite_dist   optional argument
+%                               include infinite distances in calculation
+%                                   (default: infinite_dist=1)
+%
+%   Outputs:    lambda,         network characteristic path length
+%               efficiency,     network global efficiency
+%               ecc,            nodal eccentricity
+%               radius,         network radius
+%               diameter,       network diameter
+%
+%   Notes:
+%       The input distance matrix may be obtained with any of the distance
+%   functions, e.g. distance_bin, distance_wei.
+%       Characteristic path length is defined here as the mean shortest
+%   path length between all pairs of nodes, for consistency with common
+%   usage. Note that characteristic path length is also defined as the
+%   median of the mean shortest path length from each node to all other
+%   nodes.
+%       Infinitely long paths (i.e. paths between disconnected nodes) are
+%   included in computations by default. This behavior may be modified with
+%   via the infinite_dist argument.
+%
+%
+%   Olaf Sporns, Indiana University, 2002/2007/2008
+%   Mika Rubinov, U Cambridge, 2010/2015
+
+%   Modification history
+%   2002: original (OS)
+%   2010: incorporation of global efficiency (MR)
+%   2015: exclusion of diagonal weights by default (MR)
+%   2016: inclusion of infinite distances by default (MR)
+
+n = size(D,1);
+if any(any(isnan(D)))
+    error('The distance matrix must not contain NaN values');
+end
+if ~exist('diagonal_dist','var') || ~diagonal_dist || isempty(diagonal_dist)
+    D(1:n+1:end) = NaN;             % set diagonal distance to NaN
+end
+if  exist('infinite_dist','var') && ~infinite_dist
+    D(isinf(D))  = NaN;             % ignore infinite path lengths
+end
+
+Dv = D(~isnan(D));                  % get non-NaN indices of D
+
+% Mean of entries of D(G)
+lambda     = mean(Dv);
+
+% Efficiency: mean of inverse entries of D(G)
+efficiency = mean(1./Dv);
+
+% Eccentricity for each vertex
+% Modified by Emiliano Gomez to get nodal eccentricity.
+D(D==Inf) = 0;
+ecc        = nanmax(D(1,:),[],2);
+ecc(isnan(ecc)) = 0;
+
+% Radius of graph
+radius     = min(ecc);
+
+% Diameter of graph
+diameter   = max(ecc);
+
+end

--- a/braph2/graph/measures/test_EccentricityAv.m
+++ b/braph2/graph/measures/test_EccentricityAv.m
@@ -1,4 +1,4 @@
-% test Eccentricity
+% test EccentricityAv
 
 %% Test 1: GraphBU
 A = [
@@ -9,22 +9,22 @@ A = [
     0     0   0   0    0
     ];
     
-known_eccentricity_subgraphs = {[1 1 1 1 0]'};
+known_eccentricity_av_subgraphs = {mean([1 1 1 1 0])};
 
 g = GraphBU(A);
-eccentricity = Eccentricity(g, 'EccentricityRule', 'subgraphs');
+eccentricity_av = EccentricityAv(g, 'EccentricityRule', 'subgraphs');
 
-assert(isequal(eccentricity.getValue(), known_eccentricity_subgraphs), ...
-    [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
-    'Eccentricity is not being calculated correctly for GraphBU.')
+assert(isequal(eccentricity_av.getValue(), known_eccentricity_av_subgraphs), ...
+    [BRAPH2.STR ':EccentricityAv:' BRAPH2.BUG_ERR], ...
+    'EccentricityAv is not being calculated correctly for GraphBU.')
 
-known_eccentricity_default = {[Inf Inf Inf Inf Inf]'};
+known_eccentricity_av_default = {mean([Inf Inf Inf Inf Inf])};
 
-eccentricity = Eccentricity(g);
+eccentricity_av = EccentricityAv(g);
 
-assert(isequal(eccentricity.getValue(), known_eccentricity_default), ...
-    [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
-    'Eccentricity is not being calculated correctly for GraphBU.')
+assert(isequal(eccentricity_av.getValue(), known_eccentricity_av_default), ...
+    [BRAPH2.STR ':EccentricityAv:' BRAPH2.BUG_ERR], ...
+    'EccentricityAv is not being calculated correctly for GraphBU.')
 
 %% Test 2: GraphWU
 A = [
@@ -35,22 +35,22 @@ A = [
     0     0   0   0    0
     ];
     
-known_eccentricity_subgraphs = {[5 5 5 4 0]'};
+known_eccentricity_av_subgraphs = {mean([5 5 5 4 0])};
 
 g = GraphWU(A);
-eccentricity = Eccentricity(g, 'EccentricityRule', 'subgraphs');
+eccentricity_av = EccentricityAv(g, 'EccentricityRule', 'subgraphs');
 
-assert(isequal(eccentricity.getValue(), known_eccentricity_subgraphs), ...
-    [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
-    'Eccentricity is not being calculated correctly for GraphWU.')
+assert(isequal(eccentricity_av.getValue(), known_eccentricity_av_subgraphs), ...
+    [BRAPH2.STR ':EccentricityAv:' BRAPH2.BUG_ERR], ...
+    'EccentricityAv is not being calculated correctly for GraphWU.')
 
-known_eccentricity_default = {[Inf Inf Inf Inf Inf]'};
+known_eccentricity_av_default = {mean([Inf Inf Inf Inf Inf])};
 
-eccentricity = Eccentricity(g);
+eccentricity_av = EccentricityAv(g);
 
-assert(isequal(eccentricity.getValue(), known_eccentricity_default), ...
-    [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
-    'Eccentricity is not being calculated correctly for GraphWU.')
+assert(isequal(eccentricity_av.getValue(), known_eccentricity_av_default), ...
+    [BRAPH2.STR ':EccentricityAv:' BRAPH2.BUG_ERR], ...
+    'EccentricityAv is not being calculated correctly for GraphWU.')
 
 %% Test 3: MultiplexGraphBU
 A11 = [
@@ -75,26 +75,26 @@ A = {
     A21     A22
     };
 
-known_eccentricity_subgraphs = {
-                                [1 1 1 1 0]'
-                                [1 1 1 1 0]'
+known_eccentricity_av_subgraphs = {
+                                mean([1 1 1 1 0])
+                                mean([1 1 1 1 0])
                                 };
 
 g = MultiplexGraphBU(A);
-eccentricity = Eccentricity(g, 'EccentricityRule', 'subgraphs');
+eccentricity_av = EccentricityAv(g, 'EccentricityRule', 'subgraphs');
 
-assert(isequal(eccentricity.getValue(), known_eccentricity_subgraphs), ...
+assert(isequal(eccentricity_av.getValue(), known_eccentricity_av_subgraphs), ...
     [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
     'Eccentricity is not being calculated correctly for MultiplexGraphBU.')
 
-known_eccentricity_default = {
-                              [Inf Inf Inf Inf Inf]'
-                              [Inf Inf Inf Inf Inf]'
+known_eccentricity_av_default = {
+                              mean([Inf Inf Inf Inf Inf])
+                              mean([Inf Inf Inf Inf Inf])
                               };
 
-eccentricity = Eccentricity(g);
+eccentricity_av = EccentricityAv(g);
 
-assert(isequal(eccentricity.getValue(), known_eccentricity_default), ...
+assert(isequal(eccentricity_av.getValue(), known_eccentricity_av_default), ...
     [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
     'Eccentricity is not being calculated correctly for MultiplexGraphBU.')
 
@@ -121,41 +121,41 @@ A = {
     A21     A22
     };
 
-known_eccentricity_subgraphs = {
-                                [5 5 5 4 0]'
-                                [5 5 5 4 0]'
+known_eccentricity_av_subgraphs = {
+                                mean([5 5 5 4 0])
+                                mean([5 5 5 4 0])
                                 };
 
 g = MultiplexGraphWU(A);
-eccentricity = Eccentricity(g, 'EccentricityRule', 'subgraphs');
+eccentricity_av = EccentricityAv(g, 'EccentricityRule', 'subgraphs');
 
-assert(isequal(eccentricity.getValue(), known_eccentricity_subgraphs), ...
+assert(isequal(eccentricity_av.getValue(), known_eccentricity_av_subgraphs), ...
     [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
     'Eccentricity is not being calculated correctly for MultiplexGraphWU.')
 
-known_eccentricity_default = {
-                              [Inf Inf Inf Inf Inf]'
-                              [Inf Inf Inf Inf Inf]'
+known_eccentricity_av_default = {
+                              mean([Inf Inf Inf Inf Inf])
+                              mean([Inf Inf Inf Inf Inf])
                               };
 
-eccentricity = Eccentricity(g);
+eccentricity_av = EccentricityAv(g);
 
-assert(isequal(eccentricity.getValue(), known_eccentricity_default), ...
+assert(isequal(eccentricity_av.getValue(), known_eccentricity_av_default), ...
     [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
     'Eccentricity is not being calculated correctly for MultiplexGraphWU.')
 
 %% Test 5: Calculation WU subgraphs vs BCT
 A = rand(randi(5));
 g = GraphWU(A);
-eccentricity = Eccentricity(g, 'EccentricityRule', 'subgraphs').getValue();
+eccentricity_av = EccentricityAv(g, 'EccentricityRule', 'subgraphs').getValue();
 
 distance = Distance(g).getValue();
-[~, ~, eccentricity_bct, ~, ~]= charpath(distance{1});
-eccentricity = eccentricity{1};
+[~, ~, eccentricity_av_bct, ~, ~]= charpath(distance{1});
+eccentricity_av = eccentricity_av{1};
 
-assert(isequal( round(eccentricity(1), 3), round(eccentricity_bct, 3)), ...
-        [BRAPH2.STR ':Eccentricity:' BRAPH2.BUG_ERR], ...
-        'Eccentricity is not being calculated correctly for BCT.')
+assert(isequal(round(eccentricity_av,3), round(mean(eccentricity_av_bct),3)), ...
+        [BRAPH2.STR ':EccentricityAv:' BRAPH2.BUG_ERR], ...
+        'EccentricityAv is not being calculated correctly for BCT.')
 
 %% Functions to calculate Eccentricity from 2019_03_03_BCT
 function  [lambda,efficiency,ecc,radius,diameter] = charpath(D,diagonal_dist,infinite_dist)
@@ -229,10 +229,9 @@ lambda     = mean(Dv);
 efficiency = mean(1./Dv);
 
 % Eccentricity for each vertex
-% Modified by Emiliano Gomez to get nodal eccentricity.
-D(D==Inf) = 0;
-ecc        = nanmax(D(1,:),[],2);
-ecc(isnan(ecc)) = 0;
+% Modified by Emiliano Gomez to get average global eccentricity.
+D(isnan(D)) = 0;
+ecc        = max(D.*(D~=Inf), [], 2);
 
 % Radius of graph
 radius     = min(ecc);

--- a/braph2/graph/measures/test_InEccentricity.m
+++ b/braph2/graph/measures/test_InEccentricity.m
@@ -1,0 +1,250 @@
+% test InEccentricity
+
+%% Test 1: GraphBD
+A = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+    
+known_in_eccentricity_subgraphs = {[1 1 1 1 0]'};
+
+g = GraphBD(A);
+in_eccentricity = InEccentricity(g, 'EccentricityRule', 'subgraphs');
+
+assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_subgraphs), ...
+    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
+    'InEccentricity is not being calculated correctly for GraphBD.')
+
+known_in_eccentricity_default = {[Inf Inf Inf Inf Inf]'};
+
+in_eccentricity = InEccentricity(g);
+
+assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_default), ...
+    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
+    'InEccentricity is not being calculated correctly for GraphBD.')
+
+%% Test 2: GraphWD
+A = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+    
+known_in_eccentricity_subgraphs = {[5 10 10 5 0]'};
+
+g = GraphWD(A);
+in_eccentricity = InEccentricity(g, 'EccentricityRule', 'subgraphs');
+
+assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_subgraphs), ...
+    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
+    'InEccentricity is not being calculated correctly for GraphWD.')
+
+known_in_eccentricity_default = {[Inf Inf Inf Inf Inf]'};
+
+in_eccentricity = InEccentricity(g);
+
+assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_default), ...
+    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
+    'InEccentricity is not being calculated correctly for GraphWD.')
+
+%% Test 3: MultiplexGraphBD
+A11 = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+A12 = eye(5);
+A21 = eye(5);
+A22 = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+
+A = {
+    A11     A12
+    A21     A22
+    };
+
+known_in_eccentricity_subgraphs = {
+                                [1 1 1 1 0]'
+                                [1 1 1 1 0]'
+                                };
+
+g = MultiplexGraphBD(A);
+in_eccentricity = InEccentricity(g, 'EccentricityRule', 'subgraphs');
+
+assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_subgraphs), ...
+    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
+    'InEccentricity is not being calculated correctly for MultiplexGraphBD.')
+
+known_in_eccentricity_default = {
+                              [Inf Inf Inf Inf Inf]'
+                              [Inf Inf Inf Inf Inf]'
+                              };
+
+in_eccentricity = InEccentricity(g);
+
+assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_default), ...
+    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
+    'InEccentricity is not being calculated correctly for MultiplexGraphBD.')
+
+%% Test 4: MultiplexGraphWD
+A11 = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+A12 = eye(5);
+A21 = eye(5);
+A22 = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+
+A = {
+    A11     A12
+    A21     A22
+    };
+
+known_in_eccentricity_subgraphs = {
+                                [5 10 10 5 0]'
+                                [5 10 10 5 0]'
+                                };
+
+g = MultiplexGraphWD(A);
+in_eccentricity = InEccentricity(g, 'EccentricityRule', 'subgraphs');
+
+assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_subgraphs), ...
+    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
+    'InEccentricity is not being calculated correctly for MultiplexGraphWD.')
+
+known_in_eccentricity_default = {
+                              [Inf Inf Inf Inf Inf]'
+                              [Inf Inf Inf Inf Inf]'
+                              };
+
+in_eccentricity = InEccentricity(g);
+
+assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_default), ...
+    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
+    'InEccentricity is not being calculated correctly for MultiplexGraphWD.')
+
+%% Test 5: Calculation WD subgraphs vs BCT
+A = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+
+g = GraphWD(A);
+in_eccentricity = InEccentricity(g, 'EccentricityRule', 'subgraphs').getValue();
+
+distance = Distance(g).getValue();
+[~, ~, in_eccentricity_bct, ~, ~]= charpath(distance{1});
+in_eccentricity = in_eccentricity{1};
+
+assert(isequal( in_eccentricity(2), in_eccentricity_bct), ...
+        [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
+        'InEccentricity is not being calculated correctly for BCT.')
+
+%% Functions to calculate Eccentricity from 2019_03_03_BCT
+function  [lambda,efficiency,ecc,radius,diameter] = charpath(D,diagonal_dist,infinite_dist)
+%CHARPATH       Characteristic path length, global efficiency and related statistics
+%
+%   lambda                                  = charpath(D);
+%   lambda                                  = charpath(D);
+%   [lambda,efficiency]                     = charpath(D);
+%   [lambda,efficiency,ecc,radius,diameter] = charpath(D,diagonal_dist,infinite_dist);
+%
+%   The network characteristic path length is the average shortest path
+%   length between all pairs of nodes in the network. The global efficiency
+%   is the average inverse shortest path length in the network. The nodal
+%   eccentricity is the maximal path length between a node and any other
+%   node in the network. The radius is the minimal eccentricity, and the
+%   diameter is the maximal eccentricity.
+%
+%   Input:      D,              distance matrix
+%               diagonal_dist   optional argument
+%                               include distances on the main diagonal
+%                                   (default: diagonal_dist=0)
+%               infinite_dist   optional argument
+%                               include infinite distances in calculation
+%                                   (default: infinite_dist=1)
+%
+%   Outputs:    lambda,         network characteristic path length
+%               efficiency,     network global efficiency
+%               ecc,            nodal eccentricity
+%               radius,         network radius
+%               diameter,       network diameter
+%
+%   Notes:
+%       The input distance matrix may be obtained with any of the distance
+%   functions, e.g. distance_bin, distance_wei.
+%       Characteristic path length is defined here as the mean shortest
+%   path length between all pairs of nodes, for consistency with common
+%   usage. Note that characteristic path length is also defined as the
+%   median of the mean shortest path length from each node to all other
+%   nodes.
+%       Infinitely long paths (i.e. paths between disconnected nodes) are
+%   included in computations by default. This behavior may be modified with
+%   via the infinite_dist argument.
+%
+%
+%   Olaf Sporns, Indiana University, 2002/2007/2008
+%   Mika Rubinov, U Cambridge, 2010/2015
+
+%   Modification history
+%   2002: original (OS)
+%   2010: incorporation of global efficiency (MR)
+%   2015: exclusion of diagonal weights by default (MR)
+%   2016: inclusion of infinite distances by default (MR)
+
+n = size(D,1);
+if any(any(isnan(D)))
+    error('The distance matrix must not contain NaN values');
+end
+if ~exist('diagonal_dist','var') || ~diagonal_dist || isempty(diagonal_dist)
+    D(1:n+1:end) = NaN;             % set diagonal distance to NaN
+end
+if  exist('infinite_dist','var') && ~infinite_dist
+    D(isinf(D))  = NaN;             % ignore infinite path lengths
+end
+
+Dv = D(~isnan(D));                  % get non-NaN indices of D
+
+% Mean of entries of D(G)
+lambda     = mean(Dv);
+
+% Efficiency: mean of inverse entries of D(G)
+efficiency = mean(1./Dv);
+
+% Eccentricity for each vertex
+% Modified by Emiliano Gomez to get nodal eccentricity.
+D(D==Inf) = 0;
+ecc        = nanmax(D(1,:),[],2);
+ecc(isnan(ecc)) = 0;
+
+% Radius of graph
+radius     = min(ecc);
+
+% Diameter of graph
+diameter   = max(ecc);
+
+end

--- a/braph2/graph/measures/test_InEccentricityAv.m
+++ b/braph2/graph/measures/test_InEccentricityAv.m
@@ -1,4 +1,4 @@
-% test InEccentricity
+% test InEccentricityAv
 
 %% Test 1: GraphBD
 A = [
@@ -9,22 +9,22 @@ A = [
     0    0  0   0   0
     ];
     
-known_in_eccentricity_subgraphs = {[1 1 1 1 0]'};
+known_in_eccentricity_av_subgraphs = {mean([1 1 1 1 0])};
 
 g = GraphBD(A);
-in_eccentricity = InEccentricity(g, 'EccentricityRule', 'subgraphs');
+in_eccentricity_av = InEccentricityAv(g, 'EccentricityRule', 'subgraphs');
 
-assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_subgraphs), ...
-    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
-    'InEccentricity is not being calculated correctly for GraphBD.')
+assert(isequal(in_eccentricity_av.getValue(), known_in_eccentricity_av_subgraphs), ...
+    [BRAPH2.STR ':InEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'InEccentricityAv is not being calculated correctly for GraphBD.')
 
-known_in_eccentricity_default = {[Inf Inf Inf Inf Inf]'};
+known_in_eccentricity_default = {mean([Inf Inf Inf Inf Inf])};
 
-in_eccentricity = InEccentricity(g);
+in_eccentricity_av = InEccentricityAv(g);
 
-assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_default), ...
-    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
-    'InEccentricity is not being calculated correctly for GraphBD.')
+assert(isequal(in_eccentricity_av.getValue(), known_in_eccentricity_default), ...
+    [BRAPH2.STR ':InEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'InEccentricityAv is not being calculated correctly for GraphBD.')
 
 %% Test 2: GraphWD
 A = [
@@ -35,22 +35,22 @@ A = [
     0    0  0   0   0
     ];
     
-known_in_eccentricity_subgraphs = {[5 10 10 5 0]'};
+known_in_eccentricity_av_subgraphs = {mean([5 10 10 5 0])};
 
 g = GraphWD(A);
-in_eccentricity = InEccentricity(g, 'EccentricityRule', 'subgraphs');
+in_eccentricity_av = InEccentricityAv(g, 'EccentricityRule', 'subgraphs');
 
-assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_subgraphs), ...
-    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
-    'InEccentricity is not being calculated correctly for GraphWD.')
+assert(isequal(in_eccentricity_av.getValue(), known_in_eccentricity_av_subgraphs), ...
+    [BRAPH2.STR ':InEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'InEccentricityAv is not being calculated correctly for GraphWD.')
 
-known_in_eccentricity_default = {[Inf Inf Inf Inf Inf]'};
+known_in_eccentricity_default = {mean([Inf Inf Inf Inf Inf])};
 
-in_eccentricity = InEccentricity(g);
+in_eccentricity_av = InEccentricityAv(g);
 
-assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_default), ...
-    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
-    'InEccentricity is not being calculated correctly for GraphWD.')
+assert(isequal(in_eccentricity_av.getValue(), known_in_eccentricity_default), ...
+    [BRAPH2.STR ':InEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'InEccentricityAv is not being calculated correctly for GraphWD.')
 
 %% Test 3: MultiplexGraphBD
 A11 = [
@@ -75,28 +75,28 @@ A = {
     A21     A22
     };
 
-known_in_eccentricity_subgraphs = {
-                                [1 1 1 1 0]'
-                                [1 1 1 1 0]'
+known_in_eccentricity_av_subgraphs = {
+                                mean([1 1 1 1 0])
+                                mean([1 1 1 1 0])
                                 };
 
 g = MultiplexGraphBD(A);
-in_eccentricity = InEccentricity(g, 'EccentricityRule', 'subgraphs');
+in_eccentricity_av = InEccentricityAv(g, 'EccentricityRule', 'subgraphs');
 
-assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_subgraphs), ...
-    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
-    'InEccentricity is not being calculated correctly for MultiplexGraphBD.')
+assert(isequal(in_eccentricity_av.getValue(), known_in_eccentricity_av_subgraphs), ...
+    [BRAPH2.STR ':InEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'InEccentricityAv is not being calculated correctly for MultiplexGraphBD.')
 
 known_in_eccentricity_default = {
-                              [Inf Inf Inf Inf Inf]'
-                              [Inf Inf Inf Inf Inf]'
+                              mean([Inf Inf Inf Inf Inf])
+                              mean([Inf Inf Inf Inf Inf])
                               };
 
-in_eccentricity = InEccentricity(g);
+in_eccentricity_av = InEccentricityAv(g);
 
-assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_default), ...
-    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
-    'InEccentricity is not being calculated correctly for MultiplexGraphBD.')
+assert(isequal(in_eccentricity_av.getValue(), known_in_eccentricity_default), ...
+    [BRAPH2.STR ':InEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'InEccentricityAv is not being calculated correctly for MultiplexGraphBD.')
 
 %% Test 4: MultiplexGraphWD
 A11 = [
@@ -121,28 +121,28 @@ A = {
     A21     A22
     };
 
-known_in_eccentricity_subgraphs = {
-                                [5 10 10 5 0]'
-                                [5 10 10 5 0]'
+known_in_eccentricity_av_subgraphs = {
+                                mean([5 10 10 5 0])
+                                mean([5 10 10 5 0])
                                 };
 
 g = MultiplexGraphWD(A);
-in_eccentricity = InEccentricity(g, 'EccentricityRule', 'subgraphs');
+in_eccentricity_av = InEccentricityAv(g, 'EccentricityRule', 'subgraphs');
 
-assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_subgraphs), ...
-    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
-    'InEccentricity is not being calculated correctly for MultiplexGraphWD.')
+assert(isequal(in_eccentricity_av.getValue(), known_in_eccentricity_av_subgraphs), ...
+    [BRAPH2.STR ':InEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'InEccentricityAv is not being calculated correctly for MultiplexGraphWD.')
 
 known_in_eccentricity_default = {
-                              [Inf Inf Inf Inf Inf]'
-                              [Inf Inf Inf Inf Inf]'
+                              mean([Inf Inf Inf Inf Inf])
+                              mean([Inf Inf Inf Inf Inf])
                               };
 
-in_eccentricity = InEccentricity(g);
+in_eccentricity_av = InEccentricityAv(g);
 
-assert(isequal(in_eccentricity.getValue(), known_in_eccentricity_default), ...
-    [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
-    'InEccentricity is not being calculated correctly for MultiplexGraphWD.')
+assert(isequal(in_eccentricity_av.getValue(), known_in_eccentricity_default), ...
+    [BRAPH2.STR ':InEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'InEccentricityAv is not being calculated correctly for MultiplexGraphWD.')
 
 %% Test 5: Calculation WD subgraphs vs BCT
 A = [
@@ -154,16 +154,16 @@ A = [
     ];
 
 g = GraphWD(A);
-in_eccentricity = InEccentricity(g, 'EccentricityRule', 'subgraphs').getValue();
+in_eccentricity_av = InEccentricityAv(g, 'EccentricityRule', 'subgraphs').getValue();
 
 distance = Distance(g).getValue();
 [~, ~, in_eccentricity_bct, ~, ~]= charpath(distance{1});
-in_eccentricity = in_eccentricity{1};
+in_eccentricity_av = in_eccentricity_av{1};
 
-assert(isequal( in_eccentricity(1), in_eccentricity_bct), ...
-        [BRAPH2.STR ':InEccentricity:' BRAPH2.BUG_ERR], ...
-        'InEccentricity is not being calculated correctly for BCT.')
-
+assert(isequal(round(in_eccentricity_av, 3), round(mean(in_eccentricity_bct), 3)), ...
+        [BRAPH2.STR ':InEccentricityAv:' BRAPH2.BUG_ERR], ...
+        'InEccentricityAv is not being calculated correctly for BCT.')
+    
 %% Functions to calculate Eccentricity from 2019_03_03_BCT
 function  [lambda,efficiency,ecc,radius,diameter] = charpath(D,diagonal_dist,infinite_dist)
 %CHARPATH       Characteristic path length, global efficiency and related statistics
@@ -236,8 +236,9 @@ lambda     = mean(Dv);
 efficiency = mean(1./Dv);
 
 % Eccentricity for each vertex
-% Modified by Emiliano Gomez to get nodal eccentricity.
-ecc        = nanmax(D(2:2,1),[],2);
+% Modified by Emiliano Gomez to get average global eccentricity.
+D(isnan(D)) = 0;
+ecc        = max(D.*(D~=Inf), [], 1)';
 
 % Radius of graph
 radius     = min(ecc);

--- a/braph2/graph/measures/test_OutEccentricity.m
+++ b/braph2/graph/measures/test_OutEccentricity.m
@@ -1,0 +1,248 @@
+% test OutEccentricity
+
+%% Test 1: GraphBD
+A = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+    
+known_in_eccentricity_subgraphs = {[1 1 1 1 0]'};
+
+g = GraphBD(A);
+out_eccentricity = OutEccentricity(g, 'EccentricityRule', 'subgraphs');
+
+assert(isequal(out_eccentricity.getValue(), known_in_eccentricity_subgraphs), ...
+    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
+    'OutEccentricity is not being calculated correctly for GraphBD.')
+
+known_out_eccentricity_default = {[Inf Inf Inf Inf Inf]'};
+
+out_eccentricity = OutEccentricity(g);
+
+assert(isequal(out_eccentricity.getValue(), known_out_eccentricity_default), ...
+    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
+    'OutEccentricity is not being calculated correctly for GraphBD.')
+
+%% Test 2: GraphWD
+A = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+    
+known_in_eccentricity_subgraphs = {[10 5 5 10 0]'};
+
+g = GraphWD(A);
+out_eccentricity = OutEccentricity(g, 'EccentricityRule', 'subgraphs');
+
+assert(isequal(out_eccentricity.getValue(), known_in_eccentricity_subgraphs), ...
+    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
+    'OutEccentricity is not being calculated correctly for GraphWD.')
+
+known_out_eccentricity_default = {[Inf Inf Inf Inf Inf]'};
+
+out_eccentricity = OutEccentricity(g);
+
+assert(isequal(out_eccentricity.getValue(), known_out_eccentricity_default), ...
+    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
+    'OutEccentricity is not being calculated correctly for GraphWD.')
+
+%% Test 3: MultiplexGraphBD
+A11 = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+A12 = eye(5);
+A21 = eye(5);
+A22 = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+
+A = {
+    A11     A12
+    A21     A22
+    };
+
+known_in_eccentricity_subgraphs = {
+                                [1 1 1 1 0]'
+                                [1 1 1 1 0]'
+                                };
+
+g = MultiplexGraphBD(A);
+out_eccentricity = OutEccentricity(g, 'EccentricityRule', 'subgraphs');
+
+assert(isequal(out_eccentricity.getValue(), known_in_eccentricity_subgraphs), ...
+    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
+    'OutEccentricity is not being calculated correctly for MultiplexGraphBD.')
+
+known_out_eccentricity_default = {
+                              [Inf Inf Inf Inf Inf]'
+                              [Inf Inf Inf Inf Inf]'
+                              };
+
+out_eccentricity = OutEccentricity(g);
+
+assert(isequal(out_eccentricity.getValue(), known_out_eccentricity_default), ...
+    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
+    'OutEccentricity is not being calculated correctly for MultiplexGraphBD.')
+
+%% Test 4: MultiplexGraphWD
+A11 = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+A12 = eye(5);
+A21 = eye(5);
+A22 = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+
+A = {
+    A11     A12
+    A21     A22
+    };
+
+known_in_eccentricity_subgraphs = {
+                                [10 5 5 10 0]'
+                                [10 5 5 10 0]'
+                                };
+
+g = MultiplexGraphWD(A);
+out_eccentricity = OutEccentricity(g, 'EccentricityRule', 'subgraphs');
+
+assert(isequal(out_eccentricity.getValue(), known_in_eccentricity_subgraphs), ...
+    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
+    'OutEccentricity is not being calculated correctly for MultiplexGraphWD.')
+
+known_out_eccentricity_default = {
+                              [Inf Inf Inf Inf Inf]'
+                              [Inf Inf Inf Inf Inf]'
+                              };
+
+out_eccentricity = OutEccentricity(g);
+
+assert(isequal(out_eccentricity.getValue(), known_out_eccentricity_default), ...
+    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
+    'OutEccentricity is not being calculated correctly for MultiplexGraphWD.')
+
+%% Test 5: Calculation WD subgraphs vs BCT
+A = [
+    0   .1  0   0   0
+    .2   0  0   0   0
+    0    0  0  .2   0
+    0    0 .1   0   0
+    0    0  0   0   0
+    ];
+
+g = GraphWD(A);
+out_eccentricity = OutEccentricity(g, 'EccentricityRule', 'subgraphs').getValue();
+
+distance = Distance(g).getValue();
+[~, ~, out_eccentricity_bct, ~, ~]= charpath(distance{1});
+out_eccentricity = out_eccentricity{1};
+
+assert(isequal(out_eccentricity(1), out_eccentricity_bct), ...
+        [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
+        'OutEccentricity is not being calculated correctly for BCT.')
+
+%% Functions to calculate Eccentricity from 2019_03_03_BCT
+function  [lambda,efficiency,ecc,radius,diameter] = charpath(D,diagonal_dist,infinite_dist)
+%CHARPATH       Characteristic path length, global efficiency and related statistics
+%
+%   lambda                                  = charpath(D);
+%   lambda                                  = charpath(D);
+%   [lambda,efficiency]                     = charpath(D);
+%   [lambda,efficiency,ecc,radius,diameter] = charpath(D,diagonal_dist,infinite_dist);
+%
+%   The network characteristic path length is the average shortest path
+%   length between all pairs of nodes in the network. The global efficiency
+%   is the average inverse shortest path length in the network. The nodal
+%   eccentricity is the maximal path length between a node and any other
+%   node in the network. The radius is the minimal eccentricity, and the
+%   diameter is the maximal eccentricity.
+%
+%   Input:      D,              distance matrix
+%               diagonal_dist   optional argument
+%                               include distances on the main diagonal
+%                                   (default: diagonal_dist=0)
+%               infinite_dist   optional argument
+%                               include infinite distances in calculation
+%                                   (default: infinite_dist=1)
+%
+%   Outputs:    lambda,         network characteristic path length
+%               efficiency,     network global efficiency
+%               ecc,            nodal eccentricity
+%               radius,         network radius
+%               diameter,       network diameter
+%
+%   Notes:
+%       The input distance matrix may be obtained with any of the distance
+%   functions, e.g. distance_bin, distance_wei.
+%       Characteristic path length is defined here as the mean shortest
+%   path length between all pairs of nodes, for consistency with common
+%   usage. Note that characteristic path length is also defined as the
+%   median of the mean shortest path length from each node to all other
+%   nodes.
+%       Infinitely long paths (i.e. paths between disconnected nodes) are
+%   included in computations by default. This behavior may be modified with
+%   via the infinite_dist argument.
+%
+%
+%   Olaf Sporns, Indiana University, 2002/2007/2008
+%   Mika Rubinov, U Cambridge, 2010/2015
+
+%   Modification history
+%   2002: original (OS)
+%   2010: incorporation of global efficiency (MR)
+%   2015: exclusion of diagonal weights by default (MR)
+%   2016: inclusion of infinite distances by default (MR)
+
+n = size(D,1);
+if any(any(isnan(D)))
+    error('The distance matrix must not contain NaN values');
+end
+if ~exist('diagonal_dist','var') || ~diagonal_dist || isempty(diagonal_dist)
+    D(1:n+1:end) = NaN;             % set diagonal distance to NaN
+end
+if  exist('infinite_dist','var') && ~infinite_dist
+    D(isinf(D))  = NaN;             % ignore infinite path lengths
+end
+
+Dv = D(~isnan(D));                  % get non-NaN indices of D
+
+% Mean of entries of D(G)
+lambda     = mean(Dv);
+
+% Efficiency: mean of inverse entries of D(G)
+efficiency = mean(1./Dv);
+
+% Eccentricity for each vertex
+% Modified by Emiliano Gomez to get nodal eccentricity.
+ecc        = nanmax(D(1,2:2),[],2);
+
+% Radius of graph
+radius     = min(ecc);
+
+% Diameter of graph
+diameter   = max(ecc);
+
+end

--- a/braph2/graph/measures/test_OutEccentricityAv.m
+++ b/braph2/graph/measures/test_OutEccentricityAv.m
@@ -1,4 +1,4 @@
-% test OutEccentricity
+% test OutEccentricityAv
 
 %% Test 1: GraphBD
 A = [
@@ -9,22 +9,22 @@ A = [
     0    0  0   0   0
     ];
     
-known_out_eccentricity_subgraphs = {[1 1 1 1 0]'};
+known_out_eccentricity_av_subgraphs = {mean([1 1 1 1 0])};
 
 g = GraphBD(A);
-out_eccentricity = OutEccentricity(g, 'EccentricityRule', 'subgraphs');
+out_eccentricity_av = OutEccentricityAv(g, 'EccentricityRule', 'subgraphs');
 
-assert(isequal(out_eccentricity.getValue(), known_out_eccentricity_subgraphs), ...
-    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
-    'OutEccentricity is not being calculated correctly for GraphBD.')
+assert(isequal(out_eccentricity_av.getValue(), known_out_eccentricity_av_subgraphs), ...
+    [BRAPH2.STR ':OutEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'OutEccentricityAv is not being calculated correctly for GraphBD.')
 
-known_out_eccentricity_default = {[Inf Inf Inf Inf Inf]'};
+known_out_eccentricity_default = {mean([Inf Inf Inf Inf Inf])};
 
-out_eccentricity = OutEccentricity(g);
+out_eccentricity_av = OutEccentricityAv(g);
 
-assert(isequal(out_eccentricity.getValue(), known_out_eccentricity_default), ...
-    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
-    'OutEccentricity is not being calculated correctly for GraphBD.')
+assert(isequal(out_eccentricity_av.getValue(), known_out_eccentricity_default), ...
+    [BRAPH2.STR ':OutEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'OutEccentricityAv is not being calculated correctly for GraphBD.')
 
 %% Test 2: GraphWD
 A = [
@@ -35,22 +35,22 @@ A = [
     0    0  0   0   0
     ];
     
-known_out_eccentricity_subgraphs = {[10 5 5 10 0]'};
+known_out_eccentricity_av_subgraphs = {mean([10 5 5 10 0])};
 
 g = GraphWD(A);
-out_eccentricity = OutEccentricity(g, 'EccentricityRule', 'subgraphs');
+out_eccentricity_av = OutEccentricityAv(g, 'EccentricityRule', 'subgraphs');
 
-assert(isequal(out_eccentricity.getValue(), known_out_eccentricity_subgraphs), ...
-    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
-    'OutEccentricity is not being calculated correctly for GraphWD.')
+assert(isequal(out_eccentricity_av.getValue(), known_out_eccentricity_av_subgraphs), ...
+    [BRAPH2.STR ':OutEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'OutEccentricityAv is not being calculated correctly for GraphWD.')
 
-known_out_eccentricity_default = {[Inf Inf Inf Inf Inf]'};
+known_out_eccentricity_default = {mean([Inf Inf Inf Inf Inf])};
 
-out_eccentricity = OutEccentricity(g);
+out_eccentricity_av = OutEccentricityAv(g);
 
-assert(isequal(out_eccentricity.getValue(), known_out_eccentricity_default), ...
-    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
-    'OutEccentricity is not being calculated correctly for GraphWD.')
+assert(isequal(out_eccentricity_av.getValue(), known_out_eccentricity_default), ...
+    [BRAPH2.STR ':OutEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'OutEccentricityAv is not being calculated correctly for GraphWD.')
 
 %% Test 3: MultiplexGraphBD
 A11 = [
@@ -75,28 +75,28 @@ A = {
     A21     A22
     };
 
-known_out_eccentricity_subgraphs = {
-                                [1 1 1 1 0]'
-                                [1 1 1 1 0]'
+known_out_eccentricity_av_subgraphs = {
+                                mean([1 1 1 1 0])
+                                mean([1 1 1 1 0])
                                 };
 
 g = MultiplexGraphBD(A);
-out_eccentricity = OutEccentricity(g, 'EccentricityRule', 'subgraphs');
+out_eccentricity_av = OutEccentricityAv(g, 'EccentricityRule', 'subgraphs');
 
-assert(isequal(out_eccentricity.getValue(), known_out_eccentricity_subgraphs), ...
-    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
-    'OutEccentricity is not being calculated correctly for MultiplexGraphBD.')
+assert(isequal(out_eccentricity_av.getValue(), known_out_eccentricity_av_subgraphs), ...
+    [BRAPH2.STR ':OutEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'OutEccentricityAv is not being calculated correctly for MultiplexGraphBD.')
 
 known_out_eccentricity_default = {
-                              [Inf Inf Inf Inf Inf]'
-                              [Inf Inf Inf Inf Inf]'
+                              mean([Inf Inf Inf Inf Inf])
+                              mean([Inf Inf Inf Inf Inf])
                               };
 
-out_eccentricity = OutEccentricity(g);
+out_eccentricity_av = OutEccentricityAv(g);
 
-assert(isequal(out_eccentricity.getValue(), known_out_eccentricity_default), ...
-    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
-    'OutEccentricity is not being calculated correctly for MultiplexGraphBD.')
+assert(isequal(out_eccentricity_av.getValue(), known_out_eccentricity_default), ...
+    [BRAPH2.STR ':OutEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'OutEccentricityAv is not being calculated correctly for MultiplexGraphBD.')
 
 %% Test 4: MultiplexGraphWD
 A11 = [
@@ -121,28 +121,28 @@ A = {
     A21     A22
     };
 
-known_out_eccentricity_subgraphs = {
-                                [10 5 5 10 0]'
-                                [10 5 5 10 0]'
+known_out_eccentricity_av_subgraphs = {
+                                mean([10 5 5 10 0])
+                                mean([10 5 5 10 0])
                                 };
 
 g = MultiplexGraphWD(A);
-out_eccentricity = OutEccentricity(g, 'EccentricityRule', 'subgraphs');
+out_eccentricity_av = OutEccentricityAv(g, 'EccentricityRule', 'subgraphs');
 
-assert(isequal(out_eccentricity.getValue(), known_out_eccentricity_subgraphs), ...
-    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
-    'OutEccentricity is not being calculated correctly for MultiplexGraphWD.')
+assert(isequal(out_eccentricity_av.getValue(), known_out_eccentricity_av_subgraphs), ...
+    [BRAPH2.STR ':OutEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'OutEccentricityAv is not being calculated correctly for MultiplexGraphWD.')
 
 known_out_eccentricity_default = {
-                              [Inf Inf Inf Inf Inf]'
-                              [Inf Inf Inf Inf Inf]'
+                              mean([Inf Inf Inf Inf Inf])
+                              mean([Inf Inf Inf Inf Inf])
                               };
 
-out_eccentricity = OutEccentricity(g);
+out_eccentricity_av = OutEccentricityAv(g);
 
-assert(isequal(out_eccentricity.getValue(), known_out_eccentricity_default), ...
-    [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
-    'OutEccentricity is not being calculated correctly for MultiplexGraphWD.')
+assert(isequal(out_eccentricity_av.getValue(), known_out_eccentricity_default), ...
+    [BRAPH2.STR ':OutEccentricityAv:' BRAPH2.BUG_ERR], ...
+    'OutEccentricityAv is not being calculated correctly for MultiplexGraphWD.')
 
 %% Test 5: Calculation WD subgraphs vs BCT
 A = [
@@ -154,15 +154,15 @@ A = [
     ];
 
 g = GraphWD(A);
-out_eccentricity = OutEccentricity(g, 'EccentricityRule', 'subgraphs').getValue();
+out_eccentricity_av = OutEccentricityAv(g, 'EccentricityRule', 'subgraphs').getValue();
 
 distance = Distance(g).getValue();
-[~, ~, out_eccentricity_bct, ~, ~]= charpath(distance{1});
-out_eccentricity = out_eccentricity{1};
+[~, ~, out_eccentricity_av_bct, ~, ~]= charpath(distance{1});
+out_eccentricity_av = out_eccentricity_av{1};
 
-assert(isequal(out_eccentricity(1), out_eccentricity_bct), ...
-        [BRAPH2.STR ':OutEccentricity:' BRAPH2.BUG_ERR], ...
-        'OutEccentricity is not being calculated correctly for BCT.')
+assert(isequal(round(out_eccentricity_av(1), 3), round(mean(out_eccentricity_av_bct), 3)), ...
+        [BRAPH2.STR ':OutEccentricityAv:' BRAPH2.BUG_ERR], ...
+        'OutEccentricityAv is not being calculated correctly for BCT.')
 
 %% Functions to calculate Eccentricity from 2019_03_03_BCT
 function  [lambda,efficiency,ecc,radius,diameter] = charpath(D,diagonal_dist,infinite_dist)
@@ -236,8 +236,9 @@ lambda     = mean(Dv);
 efficiency = mean(1./Dv);
 
 % Eccentricity for each vertex
-% Modified by Emiliano Gomez to get nodal eccentricity.
-ecc        = nanmax(D(1,2:2),[],2);
+% Modified by Emiliano Gomez to get average global eccentricity.
+D(isnan(D)) = 0;
+ecc        = max(D.*(D~=Inf), [], 2);
 
 % Radius of graph
 radius     = min(ecc);


### PR DESCRIPTION
Eccentricity and EccentricityAv measure is in braph folder but not in braph2.
Implement it with the new measure structure

- [x] Eccentricity
- [x] EccentricityAv
- [x] test_Eccentricity
- [x] test_EccentricityAv
- [x] InEccentricity
- [x] InEccentricityAv
- [x] test_InEccentricity
- [x] test_InEccentricityAv
- [x] OutEccentricity
- [x] OutEccentricityAv
- [x] test_OutEccentricity
- [x] test_OutEccentricityAv