### PR TITLE
BUG when no covariates folder/file - Importers functional, connectivity, functional multiplex

### DIFF
--- a/braph2genesis/workflows/connectivity/_ImporterGroupSubjectCONTXT.gen.m
+++ b/braph2genesis/workflows/connectivity/_ImporterGroupSubjectCONTXT.gen.m
@@ -58,7 +58,7 @@ if isfolder(directory)
     cov_folder = dir(directory);
     cov_folder = cov_folder([cov_folder(:).isdir] == 1);
     cov_folder = cov_folder(~ismember({cov_folder(:).name}, {'.', '..'}));
-    if isfolder([directory filesep() cov_folder.name])
+    if ~isempty(cov_folder)
         file_cov = dir(fullfile([directory filesep() cov_folder.name], '*.txt'));
         raw_covariates = readtable([directory filesep() cov_folder.name filesep() file_cov.name], 'Delimiter', '	');
         age = raw_covariates{:, 2};

--- a/braph2genesis/workflows/connectivity/_ImporterGroupSubjectCONXLS.gen.m
+++ b/braph2genesis/workflows/connectivity/_ImporterGroupSubjectCONXLS.gen.m
@@ -61,7 +61,7 @@ if isfolder(directory)
     cov_folder = dir(directory);
     cov_folder = cov_folder([cov_folder(:).isdir] == 1);
     cov_folder = cov_folder(~ismember({cov_folder(:).name}, {'.', '..'}));
-    if isfolder([directory filesep() cov_folder.name])
+    if ~isempty(cov_folder)
         file_cov_XLSX = dir(fullfile([directory filesep() cov_folder.name], '*.xlsx'));
         file_cov_XLS = dir(fullfile([directory filesep() cov_folder.name], '*.xls'));
         file_cov = [file_cov_XLSX; file_cov_XLS];

--- a/braph2genesis/workflows/functional multiplex/_ImporterGroupSubjectFUNMPTXT.gen.m
+++ b/braph2genesis/workflows/functional multiplex/_ImporterGroupSubjectFUNMPTXT.gen.m
@@ -64,7 +64,7 @@ if isfolder(directory)
             age = raw_covariates{:, 2};
             sex = raw_covariates{:, 3};
         else
-            age = ones(subjects_number,1);
+            age = ones(subject_folders, 1);
             unassigned =  {'unassigned'};
             sex = unassigned(ones(length(subject_folders), 1));
         end
@@ -72,7 +72,7 @@ if isfolder(directory)
         % get all layers per subject folder
         waitbar(.45, f, 'Processing your data ...')
         for i = 1:1:length(subject_folders)
-            if i == floor(length(subjects_folders)/2)
+            if i == floor(length(subject_folders)/2)
                  waitbar(.70, f, 'Almost there ...')  
             end
             subjects_paths = [directory filesep() subject_folders(i).name];

--- a/braph2genesis/workflows/functional multiplex/_ImporterGroupSubjectFUNMPXLS.gen.m
+++ b/braph2genesis/workflows/functional multiplex/_ImporterGroupSubjectFUNMPXLS.gen.m
@@ -68,7 +68,7 @@ if isfolder(directory)
             sex = raw_covariates(2:end, 3);
         else
             age = {[0]};
-            age = age(ones(length(files), 1));
+            age = age(ones(length(subject_folders), 1));
             unassigned =  {'unassigned'};
             sex = unassigned(ones(1, length(subject_folders)));
         end
@@ -76,7 +76,7 @@ if isfolder(directory)
         % get all layers per subject folder
         waitbar(.45, f, 'Processing your data ...')
         for i = 1:1:length(subject_folders)
-            if i == floor(length(subjects_folders)/2)
+            if i == floor(length(subject_folders)/2)
                  waitbar(.70, f, 'Almost there ...')  
             end
             subjects_paths = [directory filesep() subject_folders(i).name];

--- a/braph2genesis/workflows/functional/_ImporterGroupSubjectFUNTXT.gen.m
+++ b/braph2genesis/workflows/functional/_ImporterGroupSubjectFUNTXT.gen.m
@@ -58,7 +58,7 @@ if isfolder(directory)
     cov_folder = dir(directory);
     cov_folder = cov_folder([cov_folder(:).isdir] == 1);
     cov_folder = cov_folder(~ismember({cov_folder(:).name}, {'.', '..'}));
-    if isfolder([directory filesep() cov_folder.name])
+    if ~isempty(cov_folder)
         file_cov = dir(fullfile([directory filesep() cov_folder.name], '*.txt'));
         raw_covariates = readtable([directory filesep() cov_folder.name filesep() file_cov.name], 'Delimiter', '	');
         age = raw_covariates{:, 2};

--- a/braph2genesis/workflows/functional/_ImporterGroupSubjectFUNXLS.gen.m
+++ b/braph2genesis/workflows/functional/_ImporterGroupSubjectFUNXLS.gen.m
@@ -60,7 +60,7 @@ if isfolder(directory)
     cov_folder = dir(directory);
     cov_folder = cov_folder([cov_folder(:).isdir] == 1);
     cov_folder = cov_folder(~ismember({cov_folder(:).name}, {'.', '..'}));
-    if isfolder([directory filesep() cov_folder.name])
+    if ~isempty(cov_folder)
         file_cov_XLSX = dir(fullfile([directory filesep() cov_folder.name], '*.xlsx'));
         file_cov_XLS = dir(fullfile([directory filesep() cov_folder.name], '*.xls'));
         file_cov = [file_cov_XLSX; file_cov_XLS];

--- a/braph2genesis/workflows/structural multiplex/_ImporterGroupSubjectSTMPTXT.gen.m
+++ b/braph2genesis/workflows/structural multiplex/_ImporterGroupSubjectSTMPTXT.gen.m
@@ -80,7 +80,7 @@ if isfolder(directory)
         cov_folder = dir(directory);
         cov_folder = cov_folder([cov_folder(:).isdir] == 1);
         cov_folder = cov_folder(~ismember({cov_folder(:).name}, {'.', '..'}));
-        if isfolder([directory filesep() cov_folder.name])
+        if ~isempty(cov_folder)
             raw_covariates = readtable([directory filesep() cov_folder.name filesep() name '_covariates.txt'], 'Delimiter', '\t');
             age = raw_covariates{:, 2};
             sex = raw_covariates{:, 3};

--- a/braph2genesis/workflows/structural multiplex/_ImporterGroupSubjectSTMPXLS.gen.m
+++ b/braph2genesis/workflows/structural multiplex/_ImporterGroupSubjectSTMPXLS.gen.m
@@ -102,7 +102,6 @@ if isfolder(directory)
             if i == 1  % just 1 time
                 % info
                 subjects_info(:, :) = raw(2:end, 1:3);
-                % covariates = xlsread(fullfile(directory, files(k).name), 'Sheet', 2, 'ReadVariableNames', 1);
             end
             % multiplex data
             data = raw(2:end, 4: size(raw, 2));  % we remove id, labl, notes (column 1 to 3)


### PR DESCRIPTION
Update connectivity, functional and functional multiplex importers (XLS, TXT) in order to work when covariates folder or file are not present on the Group folder.

