### PR TITLE
Regression analysis for covariate adjustment

### DIFF
--- a/braph2genesis/src/analysis/adjustment.m
+++ b/braph2genesis/src/analysis/adjustment.m
@@ -1,0 +1,20 @@
+function adjusted_values = adjustment(values, covariates)
+% ADJUSTMENT adjusts the covariant of data
+%
+% ADJUSTED_VALUES = ADJUSTMENT(VALUES, COVARIATES) It adjusts the values in
+% numerical arrays VALUES, so the differences related to COVARIATES are removed.
+% It is achieved with regression analysis by means of least squares
+% to approximate the effect of covariate. The adjusted values are obtained 
+% from the residuals of the value after removing the effect of covariate.
+
+Y = values;
+
+% create the full covariates matrix (merge reg values + add ones)
+no = length(covariates);
+X = [ones(no, 1) covariates];
+
+% construct the model Y = XB + E and find the LS estimate of B by using  b=(X'X)^{-1}X'y
+B = inv(X'*X) * X' * Y;
+
+% get the residuals
+adjusted_values = Y - X*B;


### PR DESCRIPTION
Tested with the simple removal of sin effect
```
x = linspace(-2*pi, 2*pi);
values = sin(x') + 0.5*rand(size(x'));
covariate = sin(x');
figure
hold on
plot(values);
adjusted_values = adjustment(values, covariate);
plot(adjusted_values);
legend('original signal','regressing out the sin effect')
```
![regression_out_test](https://user-images.githubusercontent.com/30530538/154471054-4fa30ab3-0604-4ff1-90e9-87393d4e483d.jpg)