### PR TITLE
Text changes for confidence interval

### DIFF
--- a/braph2genesis/src/analysis/_PlotComparisonEnsembleLine.gen.m
+++ b/braph2genesis/src/analysis/_PlotComparisonEnsembleLine.gen.m
@@ -294,12 +294,12 @@ function f_settings = settings(pr, varargin)
         init_cil_panel()
         function init_cil_panel()
             set(ui_confidence_interval_min_checkbox, 'Position', [.04 .4 .2 .12]);
-            set(ui_confidence_interval_min_checkbox, 'String', 'Show Confidence Interval Min');
+            set(ui_confidence_interval_min_checkbox, 'String', 'Show Lower Confidence Interval');
             set(ui_confidence_interval_min_checkbox, 'Value', false);
             set(ui_confidence_interval_min_checkbox, 'Callback', {@cb_show_confidence_interval_min})
 
             set(ui_confidence_interval_max_checkbox, 'Position', [.04 .027 .2 .12]);
-            set(ui_confidence_interval_max_checkbox, 'String', 'Show Confidence Interval Max');
+            set(ui_confidence_interval_max_checkbox, 'String', 'Show Upper Confidence Interval');
             set(ui_confidence_interval_max_checkbox, 'Value', false);
             set(ui_confidence_interval_max_checkbox, 'Callback', {@cb_show_confidence_interval_max})
         end

--- a/braph2genesis/src/analysis/_PlotComparisonEnsembleMPLine.gen.m
+++ b/braph2genesis/src/analysis/_PlotComparisonEnsembleMPLine.gen.m
@@ -298,12 +298,12 @@ function f_settings = settings(pr, varargin)
         init_cil_panel()
         function init_cil_panel()
             set(ui_confidence_interval_min_checkbox, 'Position', [.04 .27 .2 .12]);
-            set(ui_confidence_interval_min_checkbox, 'String', 'Show Confidence Interval Min');
+            set(ui_confidence_interval_min_checkbox, 'String', 'Show Lower Confidence Interval');
             set(ui_confidence_interval_min_checkbox, 'Value', false);
             set(ui_confidence_interval_min_checkbox, 'Callback', {@cb_show_confidence_interval_min})
 
             set(ui_confidence_interval_max_checkbox, 'Position', [.04 .15 .2 .12]);
-            set(ui_confidence_interval_max_checkbox, 'String', 'Show Confidence Interval Max');
+            set(ui_confidence_interval_max_checkbox, 'String', 'Show Upper Confidence Interval');
             set(ui_confidence_interval_max_checkbox, 'Value', false);
             set(ui_confidence_interval_max_checkbox, 'Callback', {@cb_show_confidence_interval_max})
         end

--- a/braph2genesis/src/analysis/_PlotComparisonGroupLine.gen.m
+++ b/braph2genesis/src/analysis/_PlotComparisonGroupLine.gen.m
@@ -296,12 +296,12 @@ function f_settings = settings(pr, varargin)
         init_cil_panel()
         function init_cil_panel()
             set(ui_confidence_interval_min_checkbox, 'Position', [.04 .4 .2 .12]);
-            set(ui_confidence_interval_min_checkbox, 'String', 'Show Confidence Interval Min');
+            set(ui_confidence_interval_min_checkbox, 'String', 'Show Lower Confidence Interval');
             set(ui_confidence_interval_min_checkbox, 'Value', false, 'BackgroundColor', pr.h_settings.Color);
             set(ui_confidence_interval_min_checkbox, 'Callback', {@cb_show_confidence_interval_min})
 
             set(ui_confidence_interval_max_checkbox, 'Position', [.04 .027 .2 .12]);
-            set(ui_confidence_interval_max_checkbox, 'String', 'Show Confidence Interval Max');
+            set(ui_confidence_interval_max_checkbox, 'String', 'Show Upper Confidence Interval');
             set(ui_confidence_interval_max_checkbox, 'Value', false, 'BackgroundColor', pr.h_settings.Color);
             set(ui_confidence_interval_max_checkbox, 'Callback', {@cb_show_confidence_interval_max})
         end

--- a/braph2genesis/src/analysis/_PlotComparisonGroupMPLine.gen.m
+++ b/braph2genesis/src/analysis/_PlotComparisonGroupMPLine.gen.m
@@ -326,12 +326,12 @@ function f_settings = settings(pr, varargin)
         init_cil_panel()
         function init_cil_panel()
             set(ui_confidence_interval_min_checkbox, 'Position', [.04 .27 .2 .12]);
-            set(ui_confidence_interval_min_checkbox, 'String', 'Show Confidence Interval Min');
+            set(ui_confidence_interval_min_checkbox, 'String', 'Show Lower Confidence Interval');
             set(ui_confidence_interval_min_checkbox, 'Value', false, 'BackgroundColor', pr.h_settings.Color);
             set(ui_confidence_interval_min_checkbox, 'Callback', {@cb_show_confidence_interval_min})
 
             set(ui_confidence_interval_max_checkbox, 'Position', [.04 .14 .2 .12]);
-            set(ui_confidence_interval_max_checkbox, 'String', 'Show Confidence Interval Max');
+            set(ui_confidence_interval_max_checkbox, 'String', 'Show Upper Confidence Interval');
             set(ui_confidence_interval_max_checkbox, 'Value', false, 'BackgroundColor', pr.h_settings.Color);
             set(ui_confidence_interval_max_checkbox, 'Callback', {@cb_show_confidence_interval_max})
         end

--- a/braph2genesis/src/analysis/_PlotEnsembleLine.gen.m
+++ b/braph2genesis/src/analysis/_PlotEnsembleLine.gen.m
@@ -299,12 +299,12 @@ function f_settings = settings(pr, varargin)
     end
         function init_cil_panel()
             set(ui_confidence_interval_min_checkbox, 'Position', [.04 .4 .2 .12]);
-            set(ui_confidence_interval_min_checkbox, 'String', 'Show Confidence Interval Min');
+            set(ui_confidence_interval_min_checkbox, 'String', 'Show Lower Confidence Interval');
             set(ui_confidence_interval_min_checkbox, 'Value', false);
             set(ui_confidence_interval_min_checkbox, 'Callback', {@cb_show_confidence_interval_min})
 
             set(ui_confidence_interval_max_checkbox, 'Position', [.04 .027 .2 .12]);
-            set(ui_confidence_interval_max_checkbox, 'String', 'Show Confidence Interval Max');
+            set(ui_confidence_interval_max_checkbox, 'String', 'Show Upper Confidence Interval');
             set(ui_confidence_interval_max_checkbox, 'Value', false);
             set(ui_confidence_interval_max_checkbox, 'Callback', {@cb_show_confidence_interval_max})
         end

--- a/braph2genesis/src/gt/_PlotAnalysisLine.gen.m
+++ b/braph2genesis/src/gt/_PlotAnalysisLine.gen.m
@@ -296,12 +296,12 @@ function f_settings = settings(pr, varargin)
     end
         function init_cil_panel()
             set(ui_confidence_interval_min_checkbox, 'Position', [.04 .4 .2 .12]);
-            set(ui_confidence_interval_min_checkbox, 'String', 'Show Confidence Interval Min');
+            set(ui_confidence_interval_min_checkbox, 'String', 'Show Lower Confidence Interval');
             set(ui_confidence_interval_min_checkbox, 'Value', false);
             set(ui_confidence_interval_min_checkbox, 'Callback', {@cb_show_confidence_interval_min})
 
             set(ui_confidence_interval_max_checkbox, 'Position', [.04 .027 .2 .12]);
-            set(ui_confidence_interval_max_checkbox, 'String', 'Show Confidence Interval Max');
+            set(ui_confidence_interval_max_checkbox, 'String', 'Show Upper Confidence Interval');
             set(ui_confidence_interval_max_checkbox, 'Value', false);
             set(ui_confidence_interval_max_checkbox, 'Callback', {@cb_show_confidence_interval_max})
         end


### PR DESCRIPTION
Show **Lower**/**Upper** Confidence Interval
<img width="200" alt="image" src="https://user-images.githubusercontent.com/30530538/157038653-510eea08-33de-4538-9be0-b270760431dd.png">

The followings were tested:
- [x] test_PlotComparisonEnsembleLine
- [x] test_PlotComparisonEnsembleMPLine
- [x] test_PlotComparisonGroupLine
- [x] test_PlotComparisonGroupMPLine
- [x] test_PlotEnsembleLine
- [x] test_PlotAnalysisLine